### PR TITLE
When building an image with circle ci tag that image as the latest image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,12 @@ jobs:
      - run: docker build -t thespaghettidetective/web:0.${CIRCLE_BUILD_NUM} web
      - run: docker build -t thespaghettidetective/ml_api:0.${CIRCLE_BUILD_NUM} ml_api
 
+     # Tag the current build as latest
+     - run: docker tag thespaghettidetective/web:0.${CIRCLE_BUILD_NUM} thespaghettidetective/web:latest
+     - run: docker tag thespaghettidetective/ml_api:0.${CIRCLE_BUILD_NUM} thespaghettidetective/ml_api:latest
+       -
      # deploy the image
      - run: docker push thespaghettidetective/web:0.${CIRCLE_BUILD_NUM}
      - run: docker push thespaghettidetective/ml_api:0.${CIRCLE_BUILD_NUM}
+     - run: docker push thespaghettidetective/web:latest
+     - run: docker push thespaghettidetective/ml_api:latest


### PR DESCRIPTION
It's pretty common to have the latest tag rolling with the newest image, this change updates the circle ci process to tag it's current build as latest.