### PR TITLE
Reduce docker image sizes and update docker compose to handle alpine images

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -2,7 +2,8 @@ version: '2.4'
 
 x-web-defaults: &web-defaults
   restart: unless-stopped
-  image: thespaghettidetective/web:0.123
+  build:
+    context: web
   volumes:
     - ./web:/app
   depends_on:
@@ -34,7 +35,8 @@ services:
   ml_api:
     hostname: ml_api
     restart: unless-stopped
-    image: thespaghettidetective/ml_api:0.123
+    build:
+      context: ml_api
     environment:
         DEBUG: 'True'
         FLASK_APP: 'server.py'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,13 +51,13 @@ services:
       - "3334:3334"
     depends_on:
       - ml_api
-    command: bash -c "python manage.py collectstatic --noinput && python manage.py migrate && python manage.py runserver 0.0.0.0:3334"
+    command: sh -c "python manage.py collectstatic --noinput && python manage.py migrate && python manage.py runserver 0.0.0.0:3334"
 
   tasks:
     <<: *web-defaults
     hostname: tasks
-    command: bash -c "celery -A config worker -l info"
+    command: sh -c "celery -A config worker -l info"
 
   redis:
     restart: unless-stopped
-    image: redis:5.0
+    image: redis:5.0-alpine

--- a/ml_api/Dockerfile
+++ b/ml_api/Dockerfile
@@ -1,5 +1,6 @@
 FROM nvidia/cuda:9.0-runtime-ubuntu16.04
 WORKDIR /app
+EXPOSE 3333
 RUN apt update && \
     apt install --no-install-recommends -y libsm6 libxrender1 libfontconfig1 python3-pip python3-setuptools vim ffmpeg wget curl && \
     rm -rf /var/lib/apt/lists/* && \
@@ -14,4 +15,3 @@ RUN wget --quiet -O model/model.weights $(cat model/model.weights.url | tr -d '\
 
 ADD . .
 
-EXPOSE 3333

--- a/ml_api/Dockerfile
+++ b/ml_api/Dockerfile
@@ -1,14 +1,17 @@
-FROM nvidia/cuda:9.0-devel-ubuntu16.04
-
-RUN apt update
-RUN apt install -y libsm6 libxrender1 libfontconfig1 python3-pip vim ffmpeg wget curl
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10
-
-ADD . /app
+FROM nvidia/cuda:9.0-runtime-ubuntu16.04
 WORKDIR /app
-RUN wget --quiet -O model/model.weights $(cat model/model.weights.url | tr -d '\r')
+RUN apt update && \
+    apt install --no-install-recommends -y libsm6 libxrender1 libfontconfig1 python3-pip python3-setuptools vim ffmpeg wget curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 10 && \
+    update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10
+
+ADD requirements.txt .
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
+ADD model model
+RUN wget --quiet -O model/model.weights $(cat model/model.weights.url | tr -d '\r')
+
+ADD . .
 
 EXPOSE 3333

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,11 +1,15 @@
-FROM python:3.6
+FROM python:3.6-alpine3.9
 
-RUN apt-get update && apt-get install -y vim ffmpeg
+WORKDIR /app
+RUN apk -U add vim ffmpeg postgresql-libs && \
+    apk add --virtual .build-deps gcc musl-dev postgresql-dev zlib-dev jpeg-dev
 RUN pip install --upgrade pip
 
-ADD . /app
-WORKDIR /app
-RUN pip install -r requirements.txt
+ADD requirements.txt .
+RUN pip install -r requirements.txt && \
+    apk --purge del .build-deps
+
+ADD . .
 
 EXPOSE 3334
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.6-alpine3.9
 
 WORKDIR /app
+EXPOSE 3334
 RUN apk -U add vim ffmpeg postgresql-libs && \
     apk add --virtual .build-deps gcc musl-dev postgresql-dev zlib-dev jpeg-dev
 RUN pip install --upgrade pip
@@ -10,7 +11,5 @@ RUN pip install -r requirements.txt && \
     apk --purge del .build-deps
 
 ADD . .
-
-EXPOSE 3334
 
 RUN python manage.py collectstatic --noinput -c


### PR DESCRIPTION
fixes #42

# Overview of the changes
* ml_api now uses 9.0-runtime-ubuntu16.04 insead of 9.0-devel-ubuntu16.04
* ml_api no longer installs recommended packages (which are not requirements) and explicitly add a few packages because of this
* web now is based off of alpine
* combined a few run statements to reduce the layer count
* rearranged statements so things that don't change often (like requirements.txt or the model weights) are cached on rebuilds
* redis is now using the 5.0-alpine image

I've done some basic testing validating that the user interface seems to work as well as spaghetti detection by adding some to my print bed mid print manually, however I would not call the testing exhaustive, if there are any sort of regression tests I can run thru this I'd love to know so I could feel more confident about this change.

Image of a detected failure with the other docker image:
![image](https://user-images.githubusercontent.com/839261/56466757-aab45780-63ca-11e9-8ebd-4447254d5e05.png)

# Benchmarks:
## Machine Specs
This testing was done in a VirtualBox VM with Ubuntu 18.04 with 16GB of memory, and 4 cores (2 logical, 2 hyperthreads).

## Speed
Take note of the second test where there is a minor change to the code, that is where this change truly shines in terms of speed.

docker-compose up original (no images cached): 
> time docker-compose up -d
> ...... lots of stdout
> Creating thespaghettidetective_ml_api_1 ... done
> Creating thespaghettidetective_redis_1  ... done
> Creating thespaghettidetective_web_1    ... done
> Creating thespaghettidetective_tasks_1  ... done
> real	10m0.465s
> user	0m2.017s
> sys	0m0.370s

docker-compose up new (no images cached): 
> time docker-compose up -d
> ...... lots of stdout
> Creating thespaghettidetective_ml_api_1 ... done
> Creating thespaghettidetective_redis_1  ... done
> Creating thespaghettidetective_web_1    ... done
> Creating thespaghettidetective_tasks_1  ... done
> real	8m1.155s
> user	0m1.440s
> sys	0m0.300s

docker-compose up --build original (with a minor code change to the web project)
> time docker-compose up -d --build
> ...... lots of stdout
> Creating thespaghettidetective_redis_1  ... done
> Creating thespaghettidetective_ml_api_1 ... done
> Creating thespaghettidetective_web_1    ... done
> Creating thespaghettidetective_tasks_1  ... done
> real	**1m57.467s**
> user	0m1.069s
> sys	0m0.248s

docker-compose up --build new (with a minor code change to the web project)
> time docker-compose up -d --build
> ...... lots of stdout
> Creating thespaghettidetective_redis_1  ... done
> Creating thespaghettidetective_ml_api_1 ... done
> Creating thespaghettidetective_web_1    ... done
> Creating thespaghettidetective_tasks_1  ... done
> real	**0m15.935s**
> user	0m0.932s
> sys	0m0.266s

## Image Sizes
ml image original: 2.95GB
ml image new: 1.67GB
web image original: 1.39GB
web image new:  504MB
