### PR TITLE
Create a basic HTML template for confirmation emails

### DIFF
--- a/web/app/templates/account/email/email_confirmation_message.html
+++ b/web/app/templates/account/email/email_confirmation_message.html
@@ -1,9 +1,10 @@
 {% load account %}{% user_display user as user_display %}{% load i18n %}{% autoescape off %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Hello from {{ site_name }}!
-
+<br /><br />
 You're receiving this e-mail because user {{ user_display }} has given yours as an e-mail address to connect their account.
-
-To confirm this is correct, go to:
-{{ activate_url }}
+<br /><br />
+To confirm this is correct, go to:<br />
+<a href="{{ activate_url }}">{{ activate_url }}</a>
+<br /><br />
 {% endblocktrans %}{% endautoescape %}
 {% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Thank you from {{ site_name }}!
 {% endblocktrans %}

--- a/web/app/templates/account/email/email_confirmation_signup_message.html
+++ b/web/app/templates/account/email/email_confirmation_signup_message.html
@@ -1,0 +1,1 @@
+{% include "account/email/email_confirmation_message.html" %}


### PR DESCRIPTION
This is just a copy of the text email with a bit of HTML markup mostly to unblock users.  This can be made pretty later, given users only see it once (usually) it's low priority.  I did verify that if a client is set to not show HTML emails it does still work and they just see the text version.