### PR TITLE
Use Docker Compose Overide file for Jetson Settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,6 @@ services:
     restart: unless-stopped
     build:
       context: ml_api
-      # dockerfile: Dockerfile.aarch64   # Uncomment this line if you are running it on Jetson
     environment:
         DEBUG: 'True'
         FLASK_APP: 'server.py'

--- a/docs/jetson_guide.md
+++ b/docs/jetson_guide.md
@@ -4,13 +4,26 @@
 
 Thanks to Raymond's work, you can now easily run TSD server on Jetson. You only need to take one extra step to make it work:
 
-- Open `docker-compose.yml` file.
+- Create and or open `docker-compose.override.yml` file.
 
-- Find the following line and uncomment it:
+- Modify file to include:
 
 ```
 ...
-# dockerfile: Dockerfile.aarch64   # Uncomment this line if you are running it on Jetson
+version: '2.4'
+
+x-web-defaults: &web-defaults
+  build:
+    dockerfile: Dockerfile.base
+
+services:
+  ml_api:
+    build:
+      context: ml_api
+      dockerfile: Dockerfile.aarch64
+    environment:
+        HAS_GPU: 'True'
+    runtime: nvidia
 ...
 ```
 

--- a/docs/jetson_guide.md
+++ b/docs/jetson_guide.md
@@ -9,7 +9,6 @@ Thanks to Raymond's work, you can now easily run TSD server on Jetson. You only 
 - Modify file to include:
 
 ```
-...
 version: '2.4'
 
 x-web-defaults: &web-defaults
@@ -24,7 +23,6 @@ services:
     environment:
         HAS_GPU: 'True'
     runtime: nvidia
-...
 ```
 
 You can then follow the remaining steps by following the instructions in [README.md].


### PR DESCRIPTION
Use docker-compose.override.yml for Nvidia Jetson specific configuration. Includes web to be rebuilt using the web dockerfile.base as thespaghettidetective/web does not have an ARM64 image.
