### PR TITLE
Fix E-Mail Notification link.

### DIFF
--- a/web/app/notifications.py
+++ b/web/app/notifications.py
@@ -52,7 +52,7 @@ def send_failure_alert_email(printer, is_warning, print_paused):
         'is_warning': is_warning,
         'view_link': site.build_full_url('/printers/'),
         'cancel_link': site.build_full_url('/printers/{}/cancel/'.format(printer.id)),
-        'resume_link': site.build_full_url('/printers/{}/resume/?mute_alert=true'.format(printer.id)),
+        'resume_link': site.build_full_url('/printers/{}/resume/'.format(printer.id)),
         'insert_img': len(attachments) == 0,
     }
 


### PR DESCRIPTION
This pull should fix the issue where alerts would be muted and TSD would no longer monitor a print if EU clicks on the resume link.

Line 55 initially had mute_alert set to true. Removing that flag from the URL here does fix the issue at least after my testing.