### PR TITLE
Run as "user" instead of "root" in web container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ build-web-base-1.2:
 build-images:
 	docker-compose build --build-arg user=user --build-arg group=user --build-arg uid=$(shell id -u) --build-arg gid=$(shell id -g)
 
+build-web-and-tasks:
+	docker-compose build --build-arg user=user --build-arg group=user --build-arg uid=$(shell id -u) --build-arg gid=$(shell id -g) web tasks
+
 build-static:
 	docker-compose run --rm --name frontbuilder --no-deps                    web bash -c "cd frontend && yarn install && yarn build"
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
-.PHONY: build-frontdev build-static vue-live vue-static
+.PHONY: build-web-base-1.2 build-images build-static frontdev-up vue-live vue-static
 
-build-frontdev:
-	docker-compose build --build-arg uid=$(shell id -u) --build-arg gid=$(shell id -g) frontdev
+build-web-base-1.2:
+	docker build -t thespaghettidetective/web:base-1.2 -f web/Dockerfile.base web
+
+build-images:
+	docker-compose build --build-arg user=user --build-arg group=user --build-arg uid=$(shell id -u) --build-arg gid=$(shell id -g)
 
 build-static:
-	docker-compose run --rm frontdev bash -c "yarn install && yarn build"
+	docker-compose run --rm --name frontbuilder --no-deps                    web bash -c "cd frontend && yarn install && yarn build"
+
+frontdev-up:
+	docker-compose run --rm --name frontdev --no-deps -p 127.0.0.1:7070:7070 web bash -c "cd frontend && yarn install && yarn serve"
 
 vue-live:
 	WEBPACK_LOADER_ENABLED=True DEBUG=True docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ x-web-defaults: &web-defaults
     INTERNAL_MEDIA_HOST: 'http://web:3334'
     ML_API_HOST: 'http://ml_api:3333'
     ACCOUNT_ALLOW_SIGN_UP: 'False'  # -> set to 'True' if you want to open sign up form
+    WEBPACK_LOADER_ENABLED:
 
     #### Optional env vars below this line ###
     # TWILIO_ACCOUNT_SID: https://django-twilio.readthedocs.io/en/latest/settings.html for how to find and set the TWILIO_XXX vars

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,8 +1,26 @@
 FROM thespaghettidetective/web:base-1.2
 
-WORKDIR /app
-EXPOSE 3334
+ARG uid=0
+ARG gid=0
+ARG user=root
+ARG group=root
 
-ADD . /app
-RUN pip install -U pip
-RUN pip install -r requirements.txt
+RUN if [[ "$uid" != 0 ]]; then \
+    addgroup --gid $gid $group && \
+    adduser --disabled-password --uid $uid --ingroup $group $user && \
+    mkdir -p /home/$user /home/$user/.cache /home/$user/.ipython /home/$user/.local && \
+    mkdir -p /app/ /app/frontend /app/static_build && \
+    chown -R $user:$group /app /home/$user \
+    ; fi
+
+VOLUME /app
+VOLUME /home/$user/.cache
+VOLUME /home/$user/.ipython
+VOLUME /home/$user/.local
+
+WORKDIR /app
+
+ENV PYTHONPATH "/home/$user/.local:${PYTHONPATH}"
+ENV PATH "/home/$user/.local/bin:${PATH}"
+
+USER $user

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -13,6 +13,12 @@ RUN if [[ "$uid" != 0 ]]; then \
     chown -R $user:$group /app /home/$user \
     ; fi
 
+USER $user
+
+EXPOSE 3334
+ADD . /app
+RUN pip install -U pip && pip install -r requirements.txt
+
 VOLUME /app
 VOLUME /home/$user/.cache
 VOLUME /home/$user/.ipython
@@ -22,5 +28,3 @@ WORKDIR /app
 
 ENV PYTHONPATH "/home/$user/.local:${PYTHONPATH}"
 ENV PATH "/home/$user/.local/bin:${PATH}"
-
-USER $user

--- a/web/Dockerfile.base
+++ b/web/Dockerfile.base
@@ -2,7 +2,7 @@ FROM python:3.6-alpine3.9
 
 WORKDIR /app
 EXPOSE 3334
-RUN apk -U add bash vim ffmpeg postgresql-libs git && \
+RUN apk -U add bash vim ffmpeg postgresql-libs git inotify-tools && \
     apk add --virtual .build-deps gcc musl-dev postgresql-dev zlib-dev jpeg-dev libffi-dev
 RUN pip install --upgrade pip
 RUN apk add --update nodejs npm && npm install -g yarn


### PR DESCRIPTION
Added make commands for building images. 

* `make build-web-base-1.2` builds the base web image.
* `make build-images` rebuilds all images with extra build-arg passed. Only `web` (and `tasks`) can use them right now. Default user in these containers is going to be `user` with uid and gid of actual host user at build time.
* `make build-web-and-tasks` will just (re)build those images.

If you simply use `docker-compose build` then nothing changes, you are going to have `root` as default user inside those containers. 

I did update make commands related to frontend as well. Both building/serving now reuses web container. No docker compose overrides etc is needed to make it work anymore.

* `make build-static` builds production bundles.
* `make frontdev-up` starts the hmr capable webpack dev server. 

I kept `vue-live` and `vue-static` but those are not really needed.

Starting app with `WEBPACK_LOADER_ENABLED=True docker-compose up` and then executing `make frontdev-up` will land you into a live env. If you don't override the env var then you get the static version.