### PR TITLE
To avoid name collisions with enterprise version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: build-web-base-1.2 build-images build-static frontdev-up vue-live vue-static
 
+BASENAME = $(shell basename $(shell pwd) | tr '[:upper:]' '[:lower:]')
+
 build-web-base-1.2:
 	docker build -t thespaghettidetective/web:base-1.2 -f web/Dockerfile.base web
 
@@ -10,10 +12,10 @@ build-web-and-tasks:
 	docker-compose build --build-arg user=user --build-arg group=user --build-arg uid=$(shell id -u) --build-arg gid=$(shell id -g) web tasks
 
 build-static:
-	docker-compose run --rm --name frontbuilder --no-deps                    web bash -c "cd frontend && yarn install && yarn build"
+	docker-compose run --rm --name $(BASENAME)_frontbuilder --no-deps                    web bash -c "cd frontend && yarn install && yarn build"
 
 frontdev-up:
-	docker-compose run --rm --name frontdev --no-deps -p 127.0.0.1:7070:7070 web bash -c "cd frontend && yarn install && yarn serve"
+	docker-compose run --rm --name $(BASENAME)_frontdev --no-deps -p 127.0.0.1:7070:7070 web bash -c "cd frontend && yarn install && yarn serve"
 
 vue-live:
 	WEBPACK_LOADER_ENABLED=True DEBUG=True docker-compose up


### PR DESCRIPTION
Otherwise one might get error like this:

```ERROR: Cannot create container for service web: Conflict. The container name "/frontdev" is already in use by container "..." You have to remove (or rename) that container to be able to reuse that name.```