### PR TITLE
Login form warning for social-account users without usable password

### DIFF
--- a/web/app/templates/account/login.html
+++ b/web/app/templates/account/login.html
@@ -28,8 +28,15 @@
       <form class="login form-signin" method="POST">
         {% if form.errors %}
         <div style="padding-bottom: 0.5em">
-          <span class="text-danger">Wrong email or password.</span> <a class="button secondaryAction"
-            href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
+          {% if form.no_password_yet %}
+          <span class="text-danger">
+            Looks like you signed up using a social account and don't have a valid password.
+          </span>
+          <a class="button secondaryAction" href="{% url 'account_reset_password' %}">{% trans "Reset Your Password!" %}</a>
+          {% else %}
+          <span class="text-danger">Wrong email or password.</span>
+          <a class="button secondaryAction" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
+          {% endif %}
         </div>
         {% endif %}
         {% csrf_token %}

--- a/web/app/urls.py
+++ b/web/app/urls.py
@@ -7,6 +7,7 @@ from .views import vue_demo
 
 urlpatterns = [
     path('', web_views.index, name='index'),
+    path('accounts/login/', web_views.login, name="account_login"),
     path('consent/', web_views.consent),
     path('media/<path:file_path>', web_views.serve_jpg_file),  # semi hacky solution to serve image files
     path('printer_auth_token/<int:pk>/', web_views.printer_auth_token, name='printer_auth_token'),

--- a/web/app/views/web_views.py
+++ b/web/app/views/web_views.py
@@ -16,10 +16,12 @@ from django.utils import timezone
 from django.utils.safestring import mark_safe
 from django.views.decorators.csrf import csrf_exempt
 
+from allauth.account.views import LoginView
+
 from .view_helpers import get_print_or_404, get_printer_or_404, get_paginator, get_template_path
 
 from app.models import (User, Printer, SharedResource, PublicTimelapse, GCodeFile)
-from app.forms import PrinterForm, UserPreferencesForm
+from app.forms import PrinterForm, UserPreferencesForm, TSDLoginForm
 from lib import channels
 from lib.integrations.telegram_bot import bot_name, telegram_bot
 from lib.file_storage import save_file_obj
@@ -31,6 +33,13 @@ def index(request):
         return redirect('/consent/')
     else:
         return redirect('/printers/')
+
+
+class TSDLoginView(LoginView):
+    form_class = TSDLoginForm
+
+
+login = TSDLoginView.as_view()
 
 
 @login_required


### PR DESCRIPTION
If user signs up using google/fb then no password is set for the account. This PR displays a warning when such user tries to login using email/password pair.