### PR TITLE
Passthru messages over webrtc (webapp side)

### DIFF
--- a/web/app/static/js/printer_controls.js
+++ b/web/app/static/js/printer_controls.js
@@ -25,6 +25,10 @@ $(document).ready(function () {
 
     });
 
+    printerCard.on('gotPassThruMessage', function (e, msg) {
+      printerWs.on_passThruMessage(msg)
+    })
+
     $('.printer-controls button').on('click', function() {
         var ele = $(this);
         var axes = ele.data('axis');
@@ -33,12 +37,20 @@ $(document).ready(function () {
             if (axes == 'xy') {
                 axes = ['x', 'y'];
             }
-            printerWs.passThruToPrinter(printerId, {func: 'home', target: '_printer', args: [axes]});
+            var payload = {func: 'home', target: '_printer', args: [axes]};
+            var msgObj = printerWs.passThruToPrinter(printerId, payload);
+            if (msgObj) {
+              printerCard.trigger('sendPassThruMessage', [msgObj]);
+            }
         } else {
             var distance = parseFloat(printerCard.find('.btn-group-toggle input:checked').val());
             var jogArgs = {}
             jogArgs[axes] = distance * (ele.data('dir') == 'up' ? 1 : -1);
-            printerWs.passThruToPrinter(printerId, {func: 'jog', target: '_printer', args: [jogArgs]});
+            var payload = {func: 'jog', target: '_printer', args: [jogArgs]};
+            var msgObj = printerWs.passThruToPrinter(printerId, payload);
+            if (msgObj) {
+              printerCard.trigger('sendPassThruMessage', [msgObj]);
+            }
         }
     });
 

--- a/web/app/static/js/webrtc_streaming.js
+++ b/web/app/static/js/webrtc_streaming.js
@@ -76,6 +76,12 @@ $(document).ready(function () {
 
                 var streaming, wsUri, turnToken, turnId;
 
+                printerCard.on('sendPassThruMessage', function (e, message) {
+                  if (streaming) {
+                    streaming.data({text: JSON.stringify(message), success: function() {}})
+                  }
+                });
+
                 if (printerCard.data('share-token')) {
                     wsUri = '/ws/share_token/janus/' + printerCard.data('share-token') + '/';
                     turnToken = printerCard.data('share-token');
@@ -114,6 +120,15 @@ $(document).ready(function () {
                                 ondataopen: function (data) {
                                 },
                                 ondata: function (data) {
+                                  var msg = undefined;
+                                  try {
+                                    msg = JSON.parse(data);
+                                  } catch {
+                                    console.log('cannot parse datachannel message')
+                                  }
+                                  if (msg && 'passthru' in msg) {
+                                    printerCard.trigger('gotPassthruMessage', [msg]);
+                                  }
                                 },
                                 oncleanup: function () {
                                     printerCard.find('.remote-video').hide();

--- a/web/frontend/src/common/StreamingBox.vue
+++ b/web/frontend/src/common/StreamingBox.vue
@@ -73,6 +73,7 @@ import get from 'lodash/get'
 import ifvisible from 'ifvisible'
 
 import Janus from '@lib/janus'
+import EventBus from '@lib/event_bus'
 import webrtc from '@lib/webrtc_streaming'
 import printerStockImgSrc from '@static/img/3d_printer.png'
 
@@ -81,7 +82,6 @@ let printerSharedWebRTCUrl = token => `/ws/share_token/janus/${token}/`
 
 export default {
   name: 'StreamingBox',
-
   created() {
     this.webrtc = null
 
@@ -211,7 +211,10 @@ export default {
         onSlowLink: this.onSlowLink,
         onTrackMuted: () => this.trackMuted = true,
         onTrackUnmuted: () => this.trackMuted = false,
+        onData: this.onWebRTCData,
       })
+
+      EventBus.$on('sendOverDatachannel', this.sendOverDatachannel)
 
       this.openWebRTCForPrinter()
     },
@@ -231,6 +234,26 @@ export default {
     onWebRTCCleanup() {
       this.isVideoVisible = false
     },
+
+    onWebRTCData(jsonData) {
+      let msg = {}
+      try {
+        msg = JSON.parse(jsonData)
+      } catch {
+        // parse error
+      }
+      if ('passthru' in msg) {
+        EventBus.$emit('gotPassthruOverDatachannel', this.printer.id, msg)
+      }
+    },
+
+    sendOverDatachannel(printerId, msg) {
+      if (this.printer && printerId == this.printer.id) {
+        if (this.webrtc && this.webrtc.streaming) {
+          this.webrtc.streaming.data({text: JSON.stringify(msg), success: () => {}})
+        }
+      }
+     },
 
     /** Video warning handling */
 

--- a/web/frontend/src/common/StreamingBox.vue
+++ b/web/frontend/src/common/StreamingBox.vue
@@ -85,12 +85,10 @@ export default {
   created() {
     this.webrtc = null
 
-    if (this.isProAccount) {
-      Janus.init({
-        debug: 'all',
-        callback: this.onJanusInitalized
-      })
-    }
+    Janus.init({
+      debug: 'all',
+      callback: this.onJanusInitalized
+    })
 
     ifvisible.on('blur', () => {
       if (this.webrtc) {
@@ -212,7 +210,7 @@ export default {
         onTrackMuted: () => this.trackMuted = true,
         onTrackUnmuted: () => this.trackMuted = false,
         onData: this.onWebRTCData,
-      })
+      }, this.isProAccount)
 
       EventBus.$on('sendOverDatachannel', this.sendOverDatachannel)
 

--- a/web/frontend/src/lib/event_bus.js
+++ b/web/frontend/src/lib/event_bus.js
@@ -1,0 +1,5 @@
+import Vue from 'vue'
+
+const EventBus = new Vue()
+
+export default EventBus

--- a/web/frontend/src/lib/webrtc_streaming.js
+++ b/web/frontend/src/lib/webrtc_streaming.js
@@ -75,9 +75,11 @@ function getWebRTCManager(callbacks) {
               slowLink: function(uplink, lost) {
                 self.onSlowLink(lost)
               },
-              ondataopen: function () {
+              ondataopen: function() {
               },
-              ondata: function () {
+              ondata: function(rawData) {
+                self.onData(rawData)
+
               },
               oncleanup: function() {
                 self.onCleanup()
@@ -145,13 +147,16 @@ function getWebRTCManager(callbacks) {
       this.callbacks.onTrackMuted()
     },
     onTrackUnmuted() {
-        this.callbacks.onTrackUnmuted()
+      this.callbacks.onTrackUnmuted()
     },
     onSlowLink(lost) {
       this.callbacks.onSlowLink(lost)
     },
     onCleanup() {
       this.callbacks.onCleanup()
+    },
+    onData(rawData) {
+      this.callbacks.onData(rawData)
     },
     startStream() {
       if (this.streamId === undefined || this.streaming === undefined) {

--- a/web/frontend/src/lib/webrtc_streaming.js
+++ b/web/frontend/src/lib/webrtc_streaming.js
@@ -2,11 +2,12 @@ import get from 'lodash/get'
 import Janus from '@lib/janus'
 
 
-function getWebRTCManager(callbacks) {
+function getWebRTCManager(callbacks, videoEnabled) {
   let manager = {
     callbacks: callbacks,
     streamId: undefined,
     streaming: undefined,
+    videoEnabled: videoEnabled ?? false,
 
     connect(wsUri, token) {
       const opaqueId = 'streamingtest-' + Janus.randomString(12)
@@ -162,7 +163,7 @@ function getWebRTCManager(callbacks) {
       if (this.streamId === undefined || this.streaming === undefined) {
         return
       }
-      const body = { 'request': 'watch', id: parseInt(this.streamId) }
+      const body = { 'request': 'watch', offer_video: self.videoEnabled, id: parseInt(this.streamId) }
       this.streaming.send({ 'message': body })
     },
     stopStream() {


### PR DESCRIPTION
Passthru messages might be sent/received over webrtc datachannel (as well) for faster delivery.

Plugin branch: https://github.com/TheSpaghettiDetective/OctoPrint-TheSpaghettiDetective/pull/105
Janus branch: https://github.com/encetamasb/janus-gateway/pull/1/files

I tried to change as less code as possible. This is why all datachannel messages are emitted/processed in ws connection managers.

When testing this PR using docker-compose make sure that both server and plugin projects run in the same (docker) network.