### PR TITLE
Update the Jetson guide on Docker-compose installation

### DIFF
--- a/docs/jetson_guide.md
+++ b/docs/jetson_guide.md
@@ -6,12 +6,22 @@ Thanks to Raymond's work, you can now easily run TSD server on Jetson.
 
 The following software is required before you start installing the server:
 
-- [JetPack SDK](https://developer.nvidia.com/embedded/jetpack). If you already flashed a software on you sd card, you will have to replace it with this one. **Important:** Before you flash the new software on your sd card, you will have to fully format it first, so make sure you have backed up anything important on an external device.
+- [JetPack SDK](https://developer.nvidia.com/embedded/jetpack). If you already flashed a software on you sd card, you will have to replace it with this one. Slow download of the software from Nvidia is normal. **Important:** Before you flash the new software on your sd card, you will have to fully format it first, so make sure you have backed up anything important on an external device.
   - [Flashing Software](https://www.balena.io/etcher/)
   - [SD Card Formater](https://www.sdcard.org/downloads/formatter/)
 
-- [Docker and Docker-compose](https://dev.to/rohansawant/installing-docker-and-docker-compose-on-the-jetson-nano-4gb-2gb-in-2-simple-steps-1f4i). But you don't have to understand how Docker or Docker-compose works. This step may also take a while to complete.
+- [Docker-compose](https://docs.docker.com/compose/install/#install-using-pip) (Docker is already pre-loaded with JetPack). Currently, there is no established method of installing Docker-compose that we know will work first try for the newest version of JetPack. However, we do have a list of methods/resources that can be referred to on how to do this.
+    - Method 1: [pipenv](https://docs.docker.com/compose/install/#install-using-pip) (Alternative install options)
+        - Run `pip install --user pipenv` to install pipenv.
+        - Run `sudo pipenv install docker-compose` to (hopefully) install docker-compose. This may take a while.
 
+    - Method 2: [pip](https://docs.docker.com/compose/install/#install-using-pip) (Alternative install options)
+        - Run `sudo pip install docker-compose` to (hopefully) install docker-compose.
+
+    - Method 3: [Install some required dependencies before running the install](https://dev.to/rohansawant/installing-docker-and-docker-compose-on-the-jetson-nano-4gb-2gb-in-2-simple-steps-1f4i). Follow the listed guide.
+
+    - Method 4: [Aquire help from the Offical Discord](https://discord.gg/5bnFgzGWHY). Please first look at [this](https://discord.com/channels/614543405724205137/648759742881071124/811686583043620923) thread to see if any part of it may help you before you post. 
+  
 - git ([how to install](https://git-scm.com/downloads)).
 
 ## Get the code and start the server.


### PR DESCRIPTION
After a linked conversation on discord, i decided to add more resources on how to download docker-compose on a jetson nano. I also added a note on the download speed of JetPack SDK from the Nvidia website.