### PR TITLE
Adding a new setting to include snapshots into email

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ x-web-defaults: &web-defaults
     EMAIL_HOST_PASSWORD:    # -> your email account password
     EMAIL_PORT: 587  # DO NOT surround it with quotes. Otherwise email won't be sent!
     EMAIL_USE_TLS: 'True'
+    EMAIL_INCLUDE_SNAPSHOTS: 'False'
     DEFAULT_FROM_EMAIL: 'changeme@example.com'
     DEBUG: 'False'    # Don't set DEBUG to True, otherwise the static files will be cached in browser until hard-refresh
     SITE_USES_HTTPS: 'False' # set it to 'True' if https is set up

--- a/web/config/settings.py
+++ b/web/config/settings.py
@@ -262,6 +262,7 @@ EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
 EMAIL_PORT = os.environ.get('EMAIL_PORT')
 EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS') == 'True'
+EMAIL_INCLUDE_SNAPSHOTS = os.environ.get('EMAIL_INCLUDE_SNAPSHOTS') == 'True'
 
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL')
 

--- a/web/lib/notifications.py
+++ b/web/lib/notifications.py
@@ -511,7 +511,7 @@ def send_email(user, subject, mailing_list, template_path, ctx, img_url=None, ve
     if img_url:
         # https://github.com/TheSpaghettiDetective/TheSpaghettiDetective/issues/43
         try:
-            if not ipaddress.ip_address(urlparse(img_url).hostname).is_global:
+            if settings.EMAIL_INCLUDE_SNAPSHOTS or not ipaddress.ip_address(urlparse(img_url).hostname).is_global:
                 attachments = [('Image.jpg', requests.get(img_url).content, 'image/jpeg')]
         except:
             pass


### PR DESCRIPTION
I'm running TSD self hosted behind a proxy that add a layer of authentication.

The actual notifications system detects my server as a public one (because it is exposed by a public url) and then add a link to the snapshot into the email. But because of the requested authentication the link into the email is broken.

This new setting allows to force snapshots to be attached to the notification email. It does not change the default behavior but add extra flexibility for self hosted environements.

I hope you'll find this feature interesting, feel free to change any name if you think there aren't clear enough.
