### PR TITLE
Minimalize possibility of dropped celery tasks

### DIFF
--- a/web/app/tasks.py
+++ b/web/app/tasks.py
@@ -45,7 +45,7 @@ def process_print_events(print_id):
     compile_timelapse.delay(print_id)
 
 
-@shared_task
+@shared_task(acks_late=True)
 def compile_timelapse(print_id):
     _print = Print.objects.all_with_deleted().select_related('printer').get(id=print_id)
 

--- a/web/config/celery.py
+++ b/web/config/celery.py
@@ -22,6 +22,7 @@ class MyCelery(celery.Celery):
 celery_app = MyCelery('config')
 celery_app.conf.task_ignore_result = True
 celery_app.conf.task_store_errors_even_if_ignored = True
+celery_app.conf.worker_prefetch_multiplier = 1
 celery_app.conf.broker_transport_options = {'visibility_timeout': 3600*12}
 celery_app.conf.task_routes = {
     'app.tasks.print_notification': {'queue': 'realtime'},


### PR DESCRIPTION
Let workers have only 1 extra task (default is 4) in their local queue.
Let an unstarted app.tasks.compile_timelapse task be requeued (by adding acks_late=True) when worker is lost. 

(https://docs.celeryproject.org/en/4.4.1/userguide/optimizing.html?highlight=optimizing#prefetch-limits)