### PR TITLE
When print time left is invalid, let's not add it to the notification

### DIFF
--- a/web/lib/mobile_notifications.py
+++ b/web/lib/mobile_notifications.py
@@ -105,9 +105,13 @@ def send_print_progress(_print, op_data, existed_rotated_jpg_url):
             data['completion'] = str(round(completion or 0))
             data['title'] += f' {data["completion"] if completion else "-"}%'
             seconds_left = progress.get("printTimeLeft") or 0
-            data['title'] += f' | ⏱{shortform_duration(seconds_left)}'
-            if mobile_device.preferred_timezone:
-                data['title'] += f' | 🏁{shortform_localtime(seconds_left, mobile_device.preferred_timezone)}'
+            if (
+                isinstance(seconds_left, int) or
+                isinstance(seconds_left, float)
+            ):
+                data['title'] += f' | ⏱{shortform_duration(seconds_left)}'
+                if mobile_device.preferred_timezone:
+                    data['title'] += f' | 🏁{shortform_localtime(seconds_left, mobile_device.preferred_timezone)}'
 
         printer = _print.printer
         if printer.not_watching_reason():


### PR DESCRIPTION
Fixes an OverFlowError when value is unexpectedly a string, "*****".