### PR TITLE
Let's force reconnection when ws consumer state is corrupted

### DIFF
--- a/web/api/consumers.py
+++ b/web/api/consumers.py
@@ -76,7 +76,10 @@ class WebConsumer(JsonWebsocketConsumer):
             else:
                 serializer = PrinterSerializer(Printer.with_archived.get(id=self.printer.id))
             self.send_json(serializer.data)
-        except:
+        except Printer.DoesNotExist:
+            sentryClient.captureException()
+            self.close()
+        except Exception:
             sentryClient.captureException()
 
     @newrelic.agent.background_task()


### PR DESCRIPTION
Strange bug, printer id can become None...
