### PR TITLE
Use standard permission check flow in verification code viewset

### DIFF
--- a/web/api/serializers.py
+++ b/web/api/serializers.py
@@ -153,3 +153,7 @@ class PublicTimelapseSerializer(serializers.ModelSerializer):
 
     def get_prediction_json_url(self, obj: PublicTimelapse) -> str:
         return obj.p_json_url
+
+
+class VerifyCodeInputSerializer(serializers.Serializer):
+    code = serializers.CharField(max_length=64, required=True)

--- a/web/api/urls.py
+++ b/web/api/urls.py
@@ -37,9 +37,15 @@ router.register(
     'PrinterDiscoveryViewSet')
 
 urlpatterns = [
+    path('v1/onetimeverificationcodes/verify/',  # For compatibility with plugin <= 1.7.0
+         octoprint_views.OneTimeVerificationCodeVerifyView.as_view(),
+    ),
     path('v1/', include(router.urls)),
     path('v1/octo/pic/', octoprint_views.OctoPrintPicView.as_view()),
     path('v1/octo/ping/', octoprint_views.OctoPrinterView.as_view()),  # For compatibility with plugin < 1.5.0
     path('v1/octo/printer/', octoprint_views.OctoPrinterView.as_view()),
     path('v1/octo/unlinked/', octoprint_views.OctoPrinterDiscoveryView.as_view()),
+    path('v1/octo/verify/',
+         octoprint_views.OneTimeVerificationCodeVerifyView.as_view(),
+    ),
 ]


### PR DESCRIPTION
Frontends need to be able to distinguish Http403 (here that means unauthenticated) and Http404 cases,
when polling for verification code state updates. This is the main reason of touching this code.

Verify endpoint has different authentication requirements, by separating it the code gets clearer and more standard.

Added proper validation error reporting code here and there; these may help in detection of - otherwise silent - problems.