### PR TITLE
Create a new 3rd-party tunnel by request

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ x-web-defaults: &web-defaults
     ML_API_HOST: 'http://ml_api:3333'
     ACCOUNT_ALLOW_SIGN_UP: 'False'  # -> set to 'True' if you want to open sign up form
     WEBPACK_LOADER_ENABLED:
-    OCTOPRINT_TUNNEL_PORT_RANGE: "${OCTOPRINT_TUNNEL_PORT_RANGE-15853-15873}"
+    OCTOPRINT_TUNNEL_PORT_RANGE: '${OCTOPRINT_TUNNEL_PORT_RANGE-"15853-15873"}'
 
     #### Optional env vars below this line ###
     #TWILIO_ACCOUNT_SID: https://django-twilio.readthedocs.io/en/latest/settings.html for how to find and set the TWILIO_XXX vars

--- a/web/app/models.py
+++ b/web/app/models.py
@@ -783,5 +783,5 @@ class OctoPrintTunnel(models.Model):
         assert self.basicauth_username and self.basicauth_password
         return f'{request.scheme}://{self.basicauth_username}:{plain_basicauth_password}@{self.get_host(request)}'
 
-    def get_url(self, request):
+    def get_internal_tunnel_url(self, request):
         return f'{request.scheme}://{self.get_host(request)}'

--- a/web/app/models.py
+++ b/web/app/models.py
@@ -697,7 +697,7 @@ class OctoPrintTunnel(models.Model):
     # when tunnel is accessed by subdomain.
     subdomain_code = models.TextField(unique=True, blank=True, null=True)
 
-    # when tunnel is accessed by port. 
+    # when tunnel is accessed by port.
     port = models.IntegerField(null=True, blank=True)
 
     created_at = models.DateTimeField(auto_now_add=True)
@@ -734,7 +734,7 @@ class OctoPrintTunnel(models.Model):
                 if settings.OCTOPRINT_TUNNEL_PORT_RANGE:
                     instance.port = OctoPrintTunnel.get_a_free_port()
                 else:
-                    instance.subdomain_code=token_hex(8)
+                    instance.subdomain_code = token_hex(8)
 
                 instance.save()
                 return instance

--- a/web/app/models.py
+++ b/web/app/models.py
@@ -754,11 +754,14 @@ class OctoPrintTunnel(models.Model):
 
     def get_url(self, request):
         if self.subdomain_code:
-            return '{request.scheme}://{subdomain_code}.tunnels.{site.domain}'.format(
-                request=request,
+            host = '{subdomain_code}.tunnels.{site.domain}'.format(
                 subdomain_code=self.subdomain_code,
                 site=get_current_site(request),
             )
+        else:
+            host = f'{request.get_host().split(":")[0]}:{self.port}'
 
-        host = request.get_host().split(':')[0]
-        return f'{request.scheme}://{host}:{self.port}'
+        if self.basicauth_username and self.basicauth_password:
+            return f'{request.scheme}://{self.basicauth_username}:{self.basicauth_password}@{host}'
+        else:
+            return f'{request.scheme}://{host}'

--- a/web/app/templates/account/base.html
+++ b/web/app/templates/account/base.html
@@ -1,5 +1,7 @@
 {% extends "non_vue_layout.html" %}
 
-{% if request.GET.hide_navbar == 'true' %}
-{% block navbar %} {% endblock navbar %}
-{% endif %}
+{% block navbar %}
+  {% if request.GET.hide_navbar != 'true' %}
+  {{ block.super }}
+  {% endif %}
+{% endblock navbar %}

--- a/web/app/templates/account/base.html
+++ b/web/app/templates/account/base.html
@@ -1,1 +1,5 @@
 {% extends "non_vue_layout.html" %}
+
+{% if request.GET.hide_navbar == 'true' %}
+{% block navbar %} {% endblock navbar %}
+{% endif %}

--- a/web/app/templates/account/login.html
+++ b/web/app/templates/account/login.html
@@ -98,7 +98,7 @@
           {% if settings.ACCOUNT_ALLOW_SIGN_UP %}
           <div class="text-center pt-3 w-100">
             <div class="font-weight-light text-muted">- OR -</div>
-            <a class="btn" href="{% url 'account_signup' %}{% if redirect_field_value %}?next={{redirect_field_value}}{% endif %}">{% trans "SIGN UP" %}</a>
+            <a class="btn" href="{% url 'account_signup' %}{% if redirect_field_value %}?next={{redirect_field_value|urlencode}}{% endif %}">{% trans "SIGN UP" %}</a>
           </div>
           {% endif %}
         </div>

--- a/web/app/templates/account/signup.html
+++ b/web/app/templates/account/signup.html
@@ -13,7 +13,6 @@
 <div class="row justify-content-center logreg">
   <div class="col-sm-12 col-md-10 col-lg-8 col-xl-6">
     <div id="logreg-forms">
-
       <h1 class="text-center">{% trans "Sign Up" %}</h1>
       <div style="margin-bottom: 1rem; padding-left: 24px;">
         <div class="custom-control custom-checkbox form-check-inline">
@@ -83,7 +82,7 @@
         <div class="text-center pt-3 w-100">
           <div class="font-weight-light text-muted">- OR -</div>
           <a class="btn"
-          href="{% url 'account_login' %}{% if redirect_field_value %}?next={{redirect_field_value}}{% endif %}">{% trans "SIGN IN" %}
+          href="{% url 'account_login' %}{% if redirect_field_value %}?next={{redirect_field_value|urlencode}}{% endif %}">{% trans "SIGN IN" %}
         </div>
       </form>
     </div>

--- a/web/app/templates/new_octoprinttunnel.html
+++ b/web/app/templates/new_octoprinttunnel.html
@@ -1,0 +1,47 @@
+{% extends "non_vue_layout.html" %}
+
+{% block navbar %} {% endblock navbar %}
+
+{% block content %}
+
+{% with app_name=request.GET.app|default:"Unknown App" %}
+
+<div class="row">
+  <h2>You are about to authorize {{ app_name }} to use the OctoPrint tunnel.</h2>
+
+  <div class="text-warning">
+    Once authorized, {{ app_name }} will be able to talk to OctoPrint via the tunnel provided by The Spaghetti Detective.
+    This means you can use {{ app_name }} to control your printer anywhere, even if you are connected to the same local network as your OctoPrint.
+  </div>
+  {% if user.is_authenticated %}
+    {% if printers %}
+      <form method="POST">
+        {% csrf_token %}
+        <input type="hidden" name="app" value="{{app_name}}" />
+        {% if printers|length > 1 %}
+          <label for="printer_id">Select a printer you want to authorize:</label>
+          <select name="printer_id" id="printer_id">
+          {% for printer in printers %}
+          <option value={{printer.id}}>{{printer.name}}</option>
+          {{ priner.name }}
+          {% endfor %}
+          </select>
+        {% else %}
+        <input type="hidden" name="printer_id" value="{{printers.0.id}}" />
+          {{ printers.0.name }}
+        {% endif %}
+        <button type="submit" class="btn btn-primary btn-block">Authorize</button>
+      </form>
+    {% else %}
+      You don't have any printer in your The Spaghetti Detective account. <a class href="https://www.thespaghettidetective.com/docs/octoprint-plugin-setup/">Set one up in 56 seconds, for free.</a>
+    {% endif %}
+  {% else %}
+  <div>
+    Please&nbsp;<a class="link" href="{% url 'account_login' %}?hide_navbar=true&next={% url 'new_octoprinttunnel' %}?{{ request.GET.urlencode }}">sign in to your The Spaghetti Detective account</a>&nbsp; to continue, or &nbsp;<a class="link" href="{% url 'account_signup' %}?hide_navbar=true&next={% url 'new_octoprinttunnel' %}?{{ request.GET.urlencode }}">sign up for an free account</a>&nbsp; if you don't have one.
+  </div>
+  {% endif %}
+
+</div>
+
+{% endwith %}
+{% endblock content %}

--- a/web/app/templates/new_octoprinttunnel_succeeded.html
+++ b/web/app/templates/new_octoprinttunnel_succeeded.html
@@ -1,0 +1,10 @@
+{% extends "non_vue_layout.html" %}
+
+{% block navbar %} {% endblock navbar %}
+
+{% block content %}
+<div>
+  <h1>Succeeded!</h1>
+</div>
+
+{% endblock content %}

--- a/web/app/urls.py
+++ b/web/app/urls.py
@@ -5,6 +5,7 @@ from .views import web_views
 from .views import mobile_views
 
 from .views import tunnel_views
+from .views import tunnelv2_views
 
 urlpatterns = [
     path('', web_views.index, name='index'),
@@ -37,6 +38,9 @@ urlpatterns = [
 
     # tunnel v1/v2 page with iframe
     path('tunnel/<int:pk>/', tunnel_views.tunnel),
+    path('tunnels/<int:pk>/', tunnel_views.tunnel),
+    path('tunnels/new/', tunnelv2_views.new_octoprinttunnel, name='new_octoprinttunnel'),
+    path('tunnels/succeeded/', tunnelv2_views.new_octoprinttunnel_succeeded, name='new_octoprinttunnel_succeeded'),
 
     # Shown only in mobile apps
     path('mobile/auth/login/', mobile_views.MobileLoginView.as_view(), name='mobile_auth_login'),
@@ -49,6 +53,5 @@ urlpatterns = [
     path('mobile/gcodes/', web_views.gcodes, {"template_dir": "mobile"}),
     path('mobile/gcodes/upload/', web_views.upload_gcode_file),
     path('mobile/printers/<pk>/', web_views.edit_printer),
-    path('mobile/tunnel/<int:pk>/', tunnel_views.tunnel),
     path('mobile/printers/<int:pk>/delete/', web_views.delete_printer),
 ]

--- a/web/app/views/tunnelv2_views.py
+++ b/web/app/views/tunnelv2_views.py
@@ -80,8 +80,8 @@ def new_octoprinttunnel(request):
             raise PermissionDenied
 
         tunnel = OctoPrintTunnel.create(printer, app_name)
-        tunnel_endporint = tunnel.get_url(request)
-        return redirect(reverse('new_octoprinttunnel_succeeded') + '?tunnel_endporint=' + tunnel_endporint)
+        tunnel_endpoint = tunnel.get_url(request)
+        return redirect(reverse('new_octoprinttunnel_succeeded') + '?tunnel_endpoint=' + tunnel_endpoint)
 
     if request.user.is_authenticated:
         printers = get_printers(request)

--- a/web/app/views/tunnelv2_views.py
+++ b/web/app/views/tunnelv2_views.py
@@ -123,7 +123,7 @@ def tunnel(request, pk, template_dir=None):
 def redirect_to_tunnel_url(request, pk):
     printer = get_printer_or_404(pk, request)
     pt = OctoPrintTunnel.get_or_create_for_internal_use(printer)
-    url = pt.get_url(request)
+    url = pt.get_internal_tunnel_url(request)
     return HttpResponseRedirect(url)
 
 

--- a/web/app/views/tunnelv2_views.py
+++ b/web/app/views/tunnelv2_views.py
@@ -71,6 +71,7 @@ TIMED_OUT_HTML = """
 
 MIN_SUPPORTED_VERSION = packaging.version.parse('1.8.4')
 
+
 def new_octoprinttunnel(request):
     if request.method == 'POST':
         printer = get_printer_or_404(request.POST['printer_id'], request)
@@ -89,11 +90,13 @@ def new_octoprinttunnel(request):
             printers = printers.filter(pk__in=[int(printer_id)])
         return render(request, 'new_octoprinttunnel.html', {'printers': printers})
     else:
-        return render(request, 'new_octoprinttunnel.html') 
+        return render(request, 'new_octoprinttunnel.html')
+
 
 @login_required
 def new_octoprinttunnel_succeeded(request):
-    return render(request, 'new_octoprinttunnel_succeeded.html') 
+    return render(request, 'new_octoprinttunnel_succeeded.html')
+
 
 @login_required
 def tunnel(request, pk, template_dir=None):
@@ -130,7 +133,7 @@ def octoprint_http_tunnel(request):
     return _octoprint_http_tunnel(request, pt)
 
 
-## Helpers
+# Helpers
 
 def is_plugin_version_supported(version: str) -> bool:
     return packaging.version.parse(version) >= MIN_SUPPORTED_VERSION
@@ -175,7 +178,6 @@ def save_static_etag(func):
 
         return response
     return inner
-
 
 
 @save_static_etag

--- a/web/frontend/src/printers/PrinterCard.vue
+++ b/web/frontend/src/printers/PrinterCard.vue
@@ -395,7 +395,7 @@ export default {
       return `/printers/${this.printer.id}/`
     },
     octoPrintTunnelUrl() {
-      return `/tunnel/${this.printer.id}/`
+      return `/tunnels/${this.printer.id}/`
     },
     onSettingsToggleClicked() {
       this.section_toggles.settings = !this.section_toggles.settings

--- a/web/lib/view_helpers.py
+++ b/web/lib/view_helpers.py
@@ -1,4 +1,5 @@
 from django.shortcuts import get_object_or_404
+from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 from app.models import *
@@ -25,6 +26,8 @@ def get_paginator(objs, request, num_per_page):
     return page_obj
 
 def get_print_or_404(pk, request):
+    if not request.user.is_authenticated:
+        raise PermissionDenied
     return get_object_or_404(Print, pk=pk, user=request.user)
 
 def get_template_path(template_name, template_dir):


### PR DESCRIPTION
3rd-party app requested tunnel authorization by opening a page at:

`/tunnels/?app=app_name[&printer_id=printer_id]`

printer_id is optional.

Please review for security holes.

Also https://github.com/TheSpaghettiDetective/TheSpaghettiDetective/pull/525/files#diff-b63f8f471707ae81afb1d0d50f0b20804fddfe7286490bcfad01fcab54e1b6feR3 doesn't work as expected. Now both /accounts/login/ and /accounts/signup/ pages have no navbar even without `?hide_navbar=true` param. I'll appreciate it if you can help me figure this out.