### PR TITLE
Fixes for tunnelv2

### DIFF
--- a/web/lib/tunnelv2.py
+++ b/web/lib/tunnelv2.py
@@ -102,6 +102,7 @@ class OctoprintTunnelV2Helper(object):
 
         qs_kwargs = {
             'printer__user__is_active': True,
+            'printer__archived_at__isnull': True,
         }
 
         if subdomain_code:


### PR DESCRIPTION
(1) Do not allow access for archived printers
(2) Return WWW-Authenticate header only for "integration" tunnels