### PR TITLE
Set Secure flag for tunneled cookies

### DIFF
--- a/web/app/views/tunnelv2_views.py
+++ b/web/app/views/tunnelv2_views.py
@@ -259,7 +259,11 @@ def _octoprint_http_tunnel(request, octoprinttunnel):
         resp[k] = v
 
     for cookie in (data['response'].get('cookies', ()) or ()):
-        resp['Set-Cookie'] = cookie
+        if (
+            request.is_secure() and
+            'secure' not in cookie.lower()
+        ):
+            cookie += '; Secure'
 
     if data['response'].get('compressed', False):
         content = zlib.decompress(data['response']['content'])


### PR DESCRIPTION
Fixing warning:

  Cookie will be soon rejected because it has the “SameSite” attribute
  set to “None” or an invalid value, without the “secure” attribute.
  To know more about the “SameSite“ attribute, read
  https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite