### PR TITLE
Add tagging of octoprint commands

### DIFF
--- a/web/api/octoprint_views.py
+++ b/web/api/octoprint_views.py
@@ -160,7 +160,7 @@ def pause_if_needed(printer):
     last_alerted = printer.current_print.alerted_at or datetime.fromtimestamp(0, timezone.utc)
 
     if printer.action_on_failure == Printer.PAUSE and not printer.current_print.paused_at:
-        printer.pause_print()
+        printer.pause_print(initiator='system')
         printer.set_alert()
         send_failure_alert(printer, is_warning=False, print_paused=True)
     elif not last_alerted > last_acknowledged:

--- a/web/app/models.py
+++ b/web/app/models.py
@@ -334,7 +334,7 @@ class Printer(SafeDeleteModel):
         return True
 
     ## return: succeeded? ##
-    def pause_print(self):
+    def pause_print(self, initiator=None):
         if self.current_print is None:
             return False
 
@@ -348,7 +348,7 @@ class Printer(SafeDeleteModel):
 
         if self.bed_off_on_pause:
             args['bed_off'] = True
-        self.send_octoprint_command('pause', args=args)
+        self.send_octoprint_command('pause', args=args, initiator=initiator)
 
         return True
 
@@ -387,8 +387,8 @@ class Printer(SafeDeleteModel):
 
     # messages to printer
 
-    def send_octoprint_command(self, command, args={}):
-        channels.send_msg_to_printer(self.id, {'commands': [{'cmd': command, 'args': args}]})
+    def send_octoprint_command(self, command, args={}, initiator=None):
+        channels.send_msg_to_printer(self.id, {'commands': [{'cmd': command, 'args': args, 'initiator': initiator or 'unknown'}]})
 
     def send_should_watch_status(self, refresh=True):
         if refresh:


### PR DESCRIPTION
This is a companion PR to to https://github.com/TheSpaghettiDetective/OctoPrint-TheSpaghettiDetective/pull/158 that allows passing "tags" when sending octoprint commands. These are currently ignored by the OctoPrint TSD plugin, but can be used by other plugins to take action when TSD detects failures. 

It passes a `failure_detected` tag when TSD detects spaghetti. I intend to use this in https://github.com/smartin015/continuousprint to differentiate between when TSD pauses due to spaghetti and when it pauses via e.g. button click in the UI, with the former triggering a "clear bed and restart print" and the latter waiting for user input.  

**Why add a `tags` and not just extend `args`?** 

[The `args` field is spread](https://github.com/smartin015/OctoPrint-TheSpaghettiDetective/blob/2bfcf799848059b7b45dbee81e0facb6ec781916/octoprint_thespaghettidetective/__init__.py#L340) when invoking OctoPrint hooks, so we'd have to explicitly pass function params if we had arguments which weren't actually needed by the hook. This IMO felt messier than adding a separate field with specific semantics.

**Why an array of tags and not some other structure?** 

I'm mostly just [following the pattern established by OctoPrint](https://docs.octoprint.org/en/master/modules/printer.html?highlight=tags#octoprint.printer.PrinterInterface.pause_print), although there is some weirdness in how oprint tags are propagated  (see [#157 of the TSD plugin repo](https://github.com/TheSpaghettiDetective/OctoPrint-TheSpaghettiDetective/pull/157)).

**Why `failure_detected`?**

Open to suggestions. Seems like `failure` is the classification on the model, but just putting that seemed underspecified.


Side note: I pulled this out of some other changes I made to make TSD run on the Jetson Nano. I can test it again on my workstation if it's needed before submission.