### PR TITLE
HTTPS should be used instead of SSH for git clone in the guides

### DIFF
--- a/docs/jetson_guide.md
+++ b/docs/jetson_guide.md
@@ -29,7 +29,7 @@ should also work but we haven't tried them.
 1. Get the code:
 
 ```
-git clone -b release git@github.com:TheSpaghettiDetective/TheSpaghettiDetective.git
+git clone -b release https://github.com/TheSpaghettiDetective/TheSpaghettiDetective.git
 ```
 
 2. Run it!

--- a/docs/unraid_guide.md
+++ b/docs/unraid_guide.md
@@ -31,7 +31,7 @@ TSD can now be installed on your unRAID server the same way as the normal Linux 
 
 ```Bash
 cd /mnt/user/appdata/
-git clone -b release git@github.com:TheSpaghettiDetective/TheSpaghettiDetective.git
+git clone -b release https://github.com/TheSpaghettiDetective/TheSpaghettiDetective.git
 # from the README
 cd TheSpaghettiDetective && docker-compose up -d
 ```

--- a/docs/unraid_guide.md
+++ b/docs/unraid_guide.md
@@ -40,7 +40,7 @@ This will install TSD to your unRAID server! To update TSD, open up the terminal
 
 ```Bash
 cd /mnt/user/appdata/TheSpaghettiDetective # or where you install TSD to
-git pull origin master
+git pull 
 docker-compose up -d --force-recreate --build
 ```
 


### PR DESCRIPTION
Not all users have their public keys set up on github.

`git clone git@github.com` will fail for many users, especially the ones who don't really use github. 
