### PR TITLE
added warning that changing domains will render previous timelapses inaccessable from website

### DIFF
--- a/dotenv.example
+++ b/dotenv.example
@@ -26,6 +26,8 @@
 
 # SITE_IS_PUBLIC=False
 # set it to True if the site configured in django admin is accessible from the internet
+# NOTE: Timelapses are saved with path to its file, so changing/using domain instead of localhost will only work for future timelapses. 
+#  Existing timelapses will keep using whatever domain/localhost was configured when they were created which can make them inaccessible through the webpage
 
 # CSRF_TRUSTED_ORIGINS=
 # A list of trusted origins for unsafe requests (e.g. POST). For example: ["https://obico.mydomain.com", "https://*.example.com"]. Necessary if, for example, a Cloudflare tunnel is used for external access.

--- a/website/docs/server-guides/advanced/reverse-proxy.md
+++ b/website/docs/server-guides/advanced/reverse-proxy.md
@@ -15,6 +15,14 @@ This is a community-contributed guide. This guide is based on certain Obico comm
 Some Obico community members have found it easier to set up NGINX reverse proxy using NGINX Proxy Manager. You can try your luck by following [this community-contributed guide](nginx-proxy-manager.md).
 :::
 
+:::warning
+
+Watching or downloading recorded timelapses uses the domain saved into the timelapse when it was created. This means changing or loosing access to the domain saved in the timelapse will make render the website unable to load and show the timelapse. So if you change or go from using localhost to use a domain, previous timelapses will likely be inaccessable through the website. However new timelapses will work as expected. 
+
+So make sure to test with new timelapses after you have made changes to your domain or moved from localhost to a new site-domain. 
+
+:::
+
 You can set up a reverse proxy in front of your self-hosted Obico Server.
 
 Two configuration items need to be set differently if you are using a reverse proxy.


### PR DESCRIPTION
As discussed in #229 the .env file and documentation does not note that timelapses uses relatively stored paths from when they are created. Which means that if you change domain previous recorded timelapses are not accessable as they still point at the old domain. Same issue if you go from localhost to using a domain/reverse proxy. 

As the obico-cloud server uses providers with multiple paths/servers/domains to store the videos, they currently have to save the video url on creation, and can't just replace all requests with the same domain as the website is currently hosted on. 

I have tried to add a warning in both the .env file and the documentation. The wording could probably be better, so feel free to edit it to fit better :) 

For my personal usage where the video files are stored on same server hosting the website, I created a python script to edit the sqlite database and replace the anything in front of ``/media/...`` part of the urls with the domain you provide. So using this I changed all my past timelapses to point at my new domain, and the timelapses are thus accessible through the website again. 

**NOTE, always take backup of database before running any script on it. Tested the script with my own database, but I can not promise nothing can go wrong!** 

```python
import sqlite3
import argparse
import os

# ensure path arguments is valid path
def dir_path(string):
    if os.path.exists(string):
        return string
    else:
        raise NotADirectoryError(string)

# Try to update and replace the url of all timelapses with given value
def updateSqliteTable(db_file, new_url):
    try:
        # connect to file
        conn = sqlite3.connect(db_file)
        cursor = conn.cursor()
        print("Connected to SQLite database")

        for colum in ["video_url", "tagged_video_url", "poster_url"]:
            query = f"""
            UPDATE app_print
            SET {colum} =
                ? || substr(
                    {colum},
                    instr({colum}, '/media')
                )
            WHERE instr({colum}, '/media') > 0;
            """

            cursor.execute(query, (new_url,))
            print(f"Updated {cursor.rowcount} rows for field {colum}")
        
        conn.commit()
        print("Records Updated successfully ")
        cursor.close()

    except sqlite3.Error as error:
        print("Failed to update sqlite table", error)
    finally:
        if conn:
            conn.close()
            print("The SQLite connection is closed")


# MAIN START
parser = argparse.ArgumentParser("replace_video_url_domain")
parser.add_argument("db", help="path to the sqlite3 database file", type=dir_path)
parser.add_argument("domain", help="new domain to replace existing with", type=str)
args = parser.parse_args()

# get input arg
updateSqliteTable(args.db, args.domain)
```

Use it with: 
```
python .\replace_video_url_domain.py <path to db file> "https://mydomain.com"
```
I ran the script myself with:
```
python .\replace_video_url_domain.py .\db.sqlite3 "https://obico.mydomain.dev"
Connected to SQLite database
Updated 173 rows for field video_url
Updated 87 rows for field tagged_video_url
Updated 109 rows for field poster_url
Records Updated successfully
The SQLite connection is closed
```

**RESIGN MEDIA AFTER DB CHANGE** 
If you use the python script to edit the video urls, make sure to run the "resign_media_url" like the documentation says here: https://www.obico.io/docs/server-guides/configure/#re-generate-django_secret_key 

```
docker compose exec web ./manage.py resign_media_urls
```

Otherwise the new urls still won't work. 