### PR TITLE
Add RKNN inference backend for RK3588 (Turing Pi RK1)

### DIFF
--- a/ml_api/Dockerfile
+++ b/ml_api/Dockerfile
@@ -9,8 +9,10 @@ ADD . /app
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 
-RUN mkdir -p /model_cache/ml_api/darknet /model_cache/ml_api/onnx \
+RUN mkdir -p /model_cache/ml_api/darknet /model_cache/ml_api/onnx /model_cache/ml_api/rknn \
  && echo 'Downloading the latest failure detection AI model in Darknet format...' \
  && curl -o /model_cache/ml_api/darknet/model-weights.darknet $(cat model/model-weights.darknet.url | tr -d '\r') \
  && echo 'Downloading the latest failure detection AI model in ONNX format...' \
- && curl -o /model_cache/ml_api/onnx/model-weights.onnx $(cat model/model-weights.onnx.url | tr -d '\r')
+ && curl -o /model_cache/ml_api/onnx/model-weights.onnx $(cat model/model-weights.onnx.url | tr -d '\r') \
+ && echo 'Downloading the latest failure detection AI model in RKNN format...' \
+ && curl -L -o /model_cache/ml_api/rknn/model-weights.rknn $(cat model/model-weights.rknn.url | tr -d '\r')

--- a/ml_api/Dockerfile.base_rk3588
+++ b/ml_api/Dockerfile.base_rk3588
@@ -1,0 +1,17 @@
+# RK3588-specific base image (e.g. Turing Pi RK1)
+# No CUDA/TensorRT - uses Rockchip NPU via rknn-toolkit-lite2
+
+FROM ubuntu:22.04 as ml_api_base_rk3588
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install --no-install-recommends -y \
+    ca-certificates python3-pip wget curl
+
+WORKDIR /app
+RUN pip install --upgrade pip
+RUN pip install opencv_python_headless
+
+ADD requirements.txt ./
+RUN pip install -r requirements.txt
+
+EXPOSE 3333

--- a/ml_api/lib/detection_model.py
+++ b/ml_api/lib/detection_model.py
@@ -21,6 +21,13 @@ except Exception as e:
     print(f'Error during importing OnnxNet! - {e}')
     onnx_ready = False
 
+rknn_ready = True
+try:
+    from lib.rknn import RknnNet
+except Exception as e:
+    print(f'Error during importing RknnNet! - {e}')
+    rknn_ready = False
+
 
 def load_net(config_path, meta_path, weights_path=None):
 
@@ -42,6 +49,11 @@ def load_net(config_path, meta_path, weights_path=None):
                         raise Exception('Not loading darknet net due to previous import failure. Check earlier log for errors.')
                     net_main = YoloNet(weights, meta_path, config_path, use_gpu)
 
+                elif weights.endswith(".rknn"):
+                    if not rknn_ready:
+                        raise Exception('Not loading RKNN net due to previous import failure. Check earlier log for errors.')
+                    net_main = RknnNet(weights, meta_path, use_gpu)
+
                 else:
                     raise Exception(f'Can not recognize net from weights file surfix: {weights}')
 
@@ -60,6 +72,7 @@ def load_net(config_path, meta_path, weights_path=None):
             dict(weights_path='/model_cache/ml_api/darknet/model-weights.darknet', use_gpu=False),
             dict(weights_path='/model_cache/ml_api/onnx/model-weights.onnx', use_gpu=True),
             dict(weights_path='/model_cache/ml_api/onnx/model-weights.onnx', use_gpu=False),
+            dict(weights_path='/model_cache/ml_api/rknn/model-weights.rknn', use_gpu=False),
         ]
     if weights_path is not None:
         net_config_priority = [ dict(weights_path=weights_path, use_gpu=True), dict(weights_path=weights_path, use_gpu=False) ]
@@ -67,8 +80,6 @@ def load_net(config_path, meta_path, weights_path=None):
     net_main = try_loading_net(net_config_priority)
 
     if alt_names is None:
-        # In Python 3, the metafile default access craps out on Windows (but not Linux)
-        # Read the names file and create a list to feed to detect
         try:
             meta = Meta(meta_path)
             alt_names = meta.names
@@ -79,4 +90,3 @@ def load_net(config_path, meta_path, weights_path=None):
 
 def detect(net, image, thresh=.5, hier_thresh=.5, nms=.45, debug=False):
     return net.detect(net.meta, image, alt_names, thresh, hier_thresh, nms, debug)
-

--- a/ml_api/lib/rknn.py
+++ b/ml_api/lib/rknn.py
@@ -1,0 +1,150 @@
+from typing import List, Tuple
+import numpy as np
+import cv2
+
+from lib.meta import Meta
+from rknnlite.api import RKNNLite
+
+
+class RknnNet:
+    rknn: RKNNLite
+    meta: Meta
+    input_h: int
+    input_w: int
+
+    def __init__(self, rknn_path: str, meta_path: str, use_gpu: bool):
+        self.rknn = RKNNLite()
+        ret = self.rknn.load_rknn(rknn_path)
+        if ret != 0:
+            raise Exception(f'Failed to load RKNN model: {rknn_path} (error code {ret})')
+
+        ret = self.rknn.init_runtime()
+        if ret != 0:
+            raise Exception(f'Failed to init RKNN runtime (error code {ret})')
+
+        self.meta = Meta(meta_path)
+        self.input_h = 416
+        self.input_w = 416
+
+    def detect(self, meta, image, alt_names, thresh=.5, hier_thresh=.5, nms=.45, debug=False) -> List[Tuple[str, float, Tuple[float, float, float, float]]]:
+        width = image.shape[1]
+        height = image.shape[0]
+
+        # Preprocess input
+        resized = cv2.resize(image, (self.input_w, self.input_h), interpolation=cv2.INTER_LINEAR)
+        img_in = cv2.cvtColor(resized, cv2.COLOR_BGR2RGB)
+        img_in = np.expand_dims(img_in, axis=0)
+
+        # Run inference
+        outputs = self.rknn.inference(inputs=[img_in])
+
+        # Dequantize outputs if needed (INT8 model)
+        outputs = _dequantize_outputs(outputs)
+
+        detections = post_processing(outputs, width, height, thresh, nms, meta.names)
+        return detections[0]
+
+    def __del__(self):
+        if hasattr(self, 'rknn') and self.rknn is not None:
+            self.rknn.release()
+
+
+def _dequantize_outputs(outputs):
+    dequantized = []
+    for out in outputs:
+        arr = np.array(out, dtype=np.float32)
+        dequantized.append(arr)
+    return dequantized
+
+
+def nms_cpu(boxes, confs, nms_thresh=0.5, min_mode=False):
+    x1 = boxes[:, 0]
+    y1 = boxes[:, 1]
+    x2 = boxes[:, 2]
+    y2 = boxes[:, 3]
+
+    areas = (x2 - x1) * (y2 - y1)
+    order = confs.argsort()[::-1]
+
+    keep = []
+    while order.size > 0:
+        idx_self = order[0]
+        idx_other = order[1:]
+
+        keep.append(idx_self)
+
+        xx1 = np.maximum(x1[idx_self], x1[idx_other])
+        yy1 = np.maximum(y1[idx_self], y1[idx_other])
+        xx2 = np.minimum(x2[idx_self], x2[idx_other])
+        yy2 = np.minimum(y2[idx_self], y2[idx_other])
+
+        w = np.maximum(0.0, xx2 - xx1)
+        h = np.maximum(0.0, yy2 - yy1)
+        inter = w * h
+
+        if min_mode:
+            over = inter / np.minimum(areas[order[0]], areas[order[1:]])
+        else:
+            over = inter / (areas[order[0]] + areas[order[1:]] - inter)
+
+        inds = np.where(over <= nms_thresh)[0]
+        order = order[inds + 1]
+
+    return np.array(keep)
+
+
+def post_processing(output, width, height, conf_thresh, nms_thresh, names):
+    box_array = output[0]
+    confs = output[1]
+
+    if type(box_array).__name__ != 'ndarray':
+        box_array = box_array.cpu().detach().numpy()
+        confs = confs.cpu().detach().numpy()
+
+    num_classes = confs.shape[2]
+
+    # [batch, num, 4]
+    box_array = box_array[:, :, 0]
+
+    # [batch, num, num_classes] --> [batch, num]
+    max_conf = np.max(confs, axis=2)
+    max_id = np.argmax(confs, axis=2)
+
+    box_x1x1x2y2_to_xcycwh_scaled = lambda b: \
+        (
+            float(0.5 * width * (b[0] + b[2])),
+            float(0.5 * height * (b[1] + b[3])),
+            float(width * (b[2] - b[0])),
+            float(width * (b[3] - b[1]))
+         )
+
+    dets_batch = []
+    for i in range(box_array.shape[0]):
+
+        argwhere = max_conf[i] > conf_thresh
+        l_box_array = box_array[i, argwhere, :]
+        l_max_conf = max_conf[i, argwhere]
+        l_max_id = max_id[i, argwhere]
+
+        bboxes = []
+        for j in range(num_classes):
+
+            cls_argwhere = l_max_id == j
+            ll_box_array = l_box_array[cls_argwhere, :]
+            ll_max_conf = l_max_conf[cls_argwhere]
+            ll_max_id = l_max_id[cls_argwhere]
+
+            keep = nms_cpu(ll_box_array, ll_max_conf, nms_thresh)
+
+            if (keep.size > 0):
+                ll_box_array = ll_box_array[keep, :]
+                ll_max_conf = ll_max_conf[keep]
+                ll_max_id = ll_max_id[keep]
+
+                for k in range(ll_box_array.shape[0]):
+                    bboxes.append([ll_box_array[k, 0], ll_box_array[k, 1], ll_box_array[k, 2], ll_box_array[k, 3], ll_max_conf[k], ll_max_conf[k], ll_max_id[k]])
+
+        detections = [(names[b[6]], float(b[4]), box_x1x1x2y2_to_xcycwh_scaled((b[0], b[1], b[2], b[3]))) for b in bboxes]
+        dets_batch.append(detections)
+
+    return dets_batch

--- a/ml_api/model/model-weights.rknn.url
+++ b/ml_api/model/model-weights.rknn.url
@@ -1,0 +1,1 @@
+https://github.com/Daywalker91/Obico-rknn-model/raw/refs/heads/main/Model/obico_model_no_quant.rknn

--- a/ml_api/requirements.txt
+++ b/ml_api/requirements.txt
@@ -6,3 +6,5 @@ requests==2.31.0
 sentry_sdk[flask]==1.40.3
 Flask-Compress==1.15
 backoff
+# RKNN Toolkit Lite2 - only installed on aarch64 (RK3588 hardware)
+rknn-toolkit-lite2 ; platform_machine == "aarch64"


### PR DESCRIPTION
## Add RKNN inference backend for RK3588 (Turing Pi RK1)

Closes / related to #1136

---

### What this PR does

Adds support for running the Obico ML inference on **Rockchip RK3588-based hardware** (e.g. Turing Pi RK1) via the RKNN runtime, as an alternative backend alongside the existing CPU/CUDA/ONNX options.

Changes:
- **`ml_api/lib/rknn.py`** (new): `RknnNet` class using `RKNNLite`, with the same `detect()` interface as `OnnxNet`. Includes preprocessing, inference, dequantization, NMS and post-processing.
- **`ml_api/lib/detection_model.py`** (modified): added `RknnNet` import with the same try/except safety pattern as existing backends, `.rknn` file extension handling, and a fallback entry in `net_config_priority`.
- **`ml_api/requirements.txt`** (modified): added `rknn-toolkit-lite2` as a conditional dependency, only installed on `aarch64` hardware.
- **`ml_api/Dockerfile`** (modified): added RKNN model download step.
- **`ml_api/Dockerfile.base_rk3588`** (new): base image for RK3588 hardware without CUDA/TensorRT, using `rknn-toolkit-lite2` for NPU inference.
- **`ml_api/model/model-weights.rknn.url`** (new): URL pointing to the converted RKNN model.

---

### Model files

The converted `.rknn` model files (non-quantized and INT8) are available here:
👉 https://github.com/Daywalker91/Obico-rknn-model

---

### Notes

- `RKNNLite` (not `RKNN`) is used — this is the on-device runtime intended for RK3588 inference.
- The RKNN backend is added as a **last fallback** in `net_config_priority`, so existing darknet/ONNX setups are completely unaffected.
- Since `rknn-toolkit-lite2` is only available on aarch64, the import failure is caught gracefully and the backend is simply skipped on unsupported platforms.
- I have 4x Turing Pi RK1 nodes available for testing. Happy to test any feedback or adjustments.