### PR TITLE
RK3588 docker configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ git clone -b release https://github.com/TheSpaghettiDetective/obico-server.git
     - If you are on Mac: `cd obico-server && docker-compose up -d`
     - If you are on Windows: `cd obico-server; docker-compose up -d`
 
+To use the NPU acceleration for RK3588 boards:
+```bash
+cd obico-server && sudo docker compose -f docker-compose.yml -f docker-compose-rk3588.yml up -d
+```
+
 3. Go grab a coffee. Step 2 will take 15-30 minutes.
 
 4. If the Obico Server is running on `localhost`, there will be no step 4. If it is running on a different host, such as a VM in the cloud, go ahead to [configure the Django site](https://www.obico.io/docs/server-guides/configure/#django-site).

--- a/docker-compose-rk3588.yml
+++ b/docker-compose-rk3588.yml
@@ -1,0 +1,12 @@
+services:
+  ml_api:
+    build:
+      context: ml_api
+      args:
+        IMAGE_TAG_SUFFIX: -rk3588
+    security_opt:
+      - systempaths=unconfined
+      - apparmor=unconfined
+    devices:
+      - /dev/dri:/dev/dri
+      - /dev/mpp_service:/dev/mpp_service

--- a/ml_api/Dockerfile
+++ b/ml_api/Dockerfile
@@ -1,4 +1,5 @@
-FROM thespaghettidetective/ml_api_base:1.4
+ARG IMAGE_TAG_SUFFIX=
+FROM thespaghettidetective/ml_api_base:1.4${IMAGE_TAG_SUFFIX}
 
 RUN apt update && apt install -y curl
 

--- a/ml_api/Dockerfile.base_rk3588
+++ b/ml_api/Dockerfile.base_rk3588
@@ -7,11 +7,16 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install --no-install-recommends -y \
     ca-certificates python3-pip wget curl
 
+RUN wget -q https://github.com/airockchip/rknn-toolkit2/raw/master/rknpu2/runtime/Linux/librknn_api/aarch64/librknnrt.so \
+    -O /usr/lib/librknnrt.so \
+    && chmod 755 /usr/lib/librknnrt.so
+
 WORKDIR /app
 RUN pip install --upgrade pip
 RUN pip install opencv_python_headless
 
 ADD requirements.txt ./
-RUN pip install -r requirements.txt
+ADD requirements_rk3588.txt ./
+RUN pip install -r requirements.txt -r requirements_rk3588.txt
 
 EXPOSE 3333

--- a/ml_api/requirements.txt
+++ b/ml_api/requirements.txt
@@ -6,5 +6,3 @@ requests==2.31.0
 sentry_sdk[flask]==1.40.3
 Flask-Compress==1.15
 backoff
-# RKNN Toolkit Lite2 - only installed on aarch64 (RK3588 hardware)
-rknn-toolkit-lite2 ; platform_machine == "aarch64"

--- a/ml_api/requirements_rk3588.txt
+++ b/ml_api/requirements_rk3588.txt
@@ -1,0 +1,2 @@
+# RKNN Toolkit Lite2 - only installed on aarch64 and RK3588 hardware
+rknn-toolkit-lite2

--- a/ml_api/scripts/build_base_images.sh
+++ b/ml_api/scripts/build_base_images.sh
@@ -33,3 +33,9 @@ docker build --platform linux/arm64 -f Dockerfile.base_arm64 -t ${VERSION_BASE}-
 docker push ${VERSION_BASE}-linux-arm64
 docker manifest create ${INSECURE} ${VERSION_BASE} --amend ${VERSION_BASE}-linux-amd64 --amend ${VERSION_BASE}-linux-arm64
 docker manifest push ${INSECURE} ${VERSION_BASE}
+
+# arm64(rk3588)
+RK3588_VERSION=${VERSION_BASE}-rk3588
+echo Building $RK3588_VERSION
+docker build --platform linux/arm64 -f Dockerfile.base_rk3588 -t ${RK3588_VERSION} .
+docker push ${RK3588_VERSION}


### PR DESCRIPTION
Related to #1136 and #1137

Docker compose configuration to be used with RK3588 boards for NPU acceleration.
The `librknnrt` shared library is needed on runtime, it was missing in ``Dockerfile.base_rk3588`
causing the RKNN initialization to fail.

### Changes:
- `ml_api`: created separate `requirements_rk3588.txt` for `Dockerfile.base_rk3588`
- `ml_api`: added installation of `librknnrt.so` in `Dockerfile.base_rk3588`
- `ml_api`: added `ml_api_base` image for rk3588 build to `build_base_images.sh`
- `docker-compse`: created `docker-compose-rk3588.yml` config
- `README`: added instructions how to run the docker compose for RK3588 with NPU acceleration


### Notes

Build and run everything on:
- Radxa ROCK 5 ITX+ 32GB RAM
- OS: Armbian 26.2.1 trixie (IOT / minimal)
- kernel: 6.1.115-vendor-rk35xx


#### Initialization of RKNN testing

Managed to build and run the docker containers locally, from logs it seems like the rk3588 NPU acceleration is initialized/loaded successfully:

```txt
l_api-1  | Let's try darknet lib built with GPU support - /darknet/libdarknet_gpu.so
ml_api-1  | Nope! Failed to load darknet lib built with GPU support. erors=/darknet/libdarknet_gpu.so: cannot open shared object file: No such file or directory
ml_api-1  | Now let's try darknet lib on CPU - /darknet/libdarknet_cpu.so
ml_api-1  | Error during importing YoloNet! - /darknet/libdarknet_cpu.so: cannot open shared object file: No such file or directory
ml_api-1  | Error during importing OnnxNet! - No module named 'onnxruntime'
ml_api-1  | ----- Trying to load weights: /model_cache/ml_api/darknet/model-weights.darknet - use_gpu = True -----
ml_api-1  | Failed! - Not loading darknet net due to previous import failure. Check earlier log for errors.
ml_api-1  | ----- Trying to load weights: /model_cache/ml_api/darknet/model-weights.darknet - use_gpu = False -----
ml_api-1  | Failed! - Not loading darknet net due to previous import failure. Check earlier log for errors.
ml_api-1  | ----- Trying to load weights: /model_cache/ml_api/onnx/model-weights.onnx - use_gpu = True -----
ml_api-1  | Failed! - Not loading ONNX net due to previous import failure. Check earlier log for errors.
ml_api-1  | ----- Trying to load weights: /model_cache/ml_api/onnx/model-weights.onnx - use_gpu = False -----
ml_api-1  | Failed! - Not loading ONNX net due to previous import failure. Check earlier log for errors.
ml_api-1  | ----- Trying to load weights: /model_cache/ml_api/rknn/model-weights.rknn - use_gpu = False -----
ml_api-1  | W rknn-toolkit-lite2 version: 2.3.2
ml_api-1  | I RKNN: [14:38:21.752] RKNN Runtime Information, librknnrt version: 2.3.2 (429f97ae6b@2025-04-09T09:09:27)
ml_api-1  | I RKNN: [14:38:21.752] RKNN Driver Information, version: 0.9.8
ml_api-1  | I RKNN: [14:38:21.752] RKNN Model Information, version: 6, toolkit version: 2.3.2(compiler version: 2.3.2 (e045de294f@2025-04-07T19:48:25)), target: RKNPU v2, target platform: rk3588, framework name: ONNX, framework layout: NCHW, model inference type: static_shape
ml_api-1  | W RKNN: [14:38:21.883] query RKNN_QUERY_INPUT_DYNAMIC_RANGE error, rknn model is static shape type, please export rknn with dynamic_shapes
ml_api-1  | W Query dynamic range failed. Ret code: RKNN_ERR_MODEL_INVALID. (If it is a static shape RKNN model, please ignore the above warning message.)
ml_api-1  | Succeeded!
```

#### Inference, detentions testing

I didn't test it with any inference/detection as i am not sure how to do it.  
Additionally on master branch the web dashboard is blank after logging so couldn't even bind a printer.

### Release actions

Before releasing this change the `thespaghettidetective/ml_api_base:<version>-rk3588` docker image should be build using `build_base_images.sh` and pushed to docker registry, otherwise the rk3588 docker compose will fail to build the `ml_api` service due to missing base image.