### PR TITLE
feat: add Helm chart for Kubernetes deployment

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,131 @@
+name: Build and publish images
+
+# Obico does not publish ready-to-run server images — docker-compose builds them
+# from source. This workflow builds them from the current source and publishes
+# tagged, signed images to GHCR so Kubernetes/Helm users can consume them. The
+# ml-api service ships in two variants: a slim CPU-only image (default) and a
+# CUDA image for GPU inference.
+
+on:
+  # The release branch is the deploy branch; rebuild whenever it moves.
+  push:
+    branches: [release]
+  workflow_dispatch: {}
+
+concurrency:
+  group: build-images-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      # Publish each image independently — one failing build must not block the
+      # others.
+      fail-fast: false
+      matrix:
+        include:
+          - name: web
+            context: backend
+            file: backend/Dockerfile
+          - name: ml-api-cpu
+            context: ml_api
+            file: ml_api/Containerfile.cpu
+          - name: ml-api-gpu
+            context: ml_api
+            file: ml_api/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so the commit date and any tags are available for
+          # versioning.
+          fetch-depth: 0
+
+      - name: Compute image namespace (GHCR requires a lowercase owner)
+        id: ns
+        run: echo "ns=ghcr.io/$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
+
+      - name: Compute version
+        id: ver
+        run: |
+          # The release branch carries no tag or in-repo VERSION, so derive a
+          # CalVer from the commit date (UTC) — deterministic and monotonic with
+          # commit order. It is day-granular: two commits on the same UTC day
+          # share it, and the second run moves the tag. The sha-<short> tag below
+          # is the immutable, guaranteed-unique per-commit pin. If the project
+          # ever starts tagging releases, an exact tag on the commit takes
+          # precedence.
+          tag="$(git describe --tags --exact-match 2>/dev/null || true)"
+          if [ -n "${tag}" ]; then
+            version="${tag#v}"
+          else
+            version="$(date -u -d "@$(git show --no-patch --format=%ct HEAD)" +'%Y.%-m.%-d')"
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "short_sha=$(git rev-parse --short HEAD)" >> "${GITHUB_OUTPUT}"
+
+      - name: Move the prebuilt frontend into the web build context
+        if: matrix.name == 'web'
+        run: |
+          # The backend image expects the prebuilt Vue bundle (checked into the
+          # release branch) at /frontend, which docker-compose supplies as a bind
+          # mount. Bake it into the image instead.
+          mv frontend backend/frontend
+          echo 'RUN ln -s /app/frontend /frontend' >> backend/Dockerfile
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.ns.outputs.ns }}/obico-${{ matrix.name }}
+          tags: |
+            type=raw,value=${{ steps.ver.outputs.version }}
+            type=raw,value=sha-${{ steps.ver.outputs.short_sha }}
+            type=raw,value=release,enable={{is_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=obico-${{ matrix.name }}
+            org.opencontainers.image.description=Obico ${{ matrix.name }} image built from obico-server source
+            org.opencontainers.image.version=${{ steps.ver.outputs.version }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          # ml-api-gpu is CUDA-based and amd64-only; keep the whole matrix on
+          # amd64 for now. The CPU image can grow an arm64 variant later.
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign the image (keyless)
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ${{ steps.ns.outputs.ns }}/obico-${{ matrix.name }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"

--- a/charts/obico/.helmignore
+++ b/charts/obico/.helmignore
@@ -1,0 +1,39 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+
+# Development and testing
+tests/
+*.test.yaml
+*.md.gotmpl
+
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+
+# Artifact Hub metadata (published separately)
+artifacthub-repo.yml

--- a/charts/obico/Chart.yaml
+++ b/charts/obico/Chart.yaml
@@ -1,0 +1,37 @@
+annotations:
+  artifacthub.io/category: ai-machine-learning
+  # Valid kinds for changes: added, changed, deprecated, removed, fixed, security
+  # See: https://artifacthub.io/docs/topics/annotations/helm/
+  artifacthub.io/changes: |-
+    - kind: added
+      description: Initial Helm chart for deploying the Obico server on Kubernetes
+  artifacthub.io/license: BSD-3-Clause
+  artifacthub.io/links: |
+    - name: Obico Server
+      url: https://github.com/TheSpaghettiDetective/obico-server/
+apiVersion: v2
+name: obico
+description: Self-hosted Obico server for AI-powered 3D printer monitoring (OctoPrint/Klipper)
+type: application
+version: "0.1.0"
+# CalVer derived from the obico-server release commit these images are built from.
+appVersion: "2026.1.20"
+icon: https://www.obico.io/img/logo.svg
+home: https://www.obico.io/
+keywords:
+  - obico
+  - 3d-printing
+  - octoprint
+  - klipper
+  - monitoring
+  - ai
+  - spaghetti-detective
+  - helm-chart
+  - kubernetes
+maintainers:
+  - name: lexfrei
+    email: f@lex.la
+    url: https://github.com/lexfrei
+sources:
+  - https://github.com/TheSpaghettiDetective/obico-server/
+kubeVersion: ">=1.21.0-0"

--- a/charts/obico/README.md
+++ b/charts/obico/README.md
@@ -1,0 +1,272 @@
+# obico
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.1.20](https://img.shields.io/badge/AppVersion-2026.1.20-informational?style=flat-square)
+
+Self-hosted Obico server for AI-powered 3D printer monitoring (OctoPrint/Klipper)
+
+**Homepage:** <https://www.obico.io/>
+
+## About
+
+[Obico](https://www.obico.io/) (formerly The Spaghetti Detective) is a self-hosted server that adds remote access, webcam streaming and AI-powered failure detection to OctoPrint and Klipper 3D printers.
+
+This chart deploys the full stack:
+
+* **web** — Django application served by Daphne (API, frontend, websockets)
+* **tasks** — Celery worker + beat scheduler (runs in the same pod as web)
+* **ml-api** — Flask/Gunicorn AI inference service for print-failure detection
+* **redis** — bundled Celery broker / Django Channels layer / cache
+
+## Images
+
+Obico's docker-compose builds the server images from source. This chart consumes prebuilt, tagged equivalents produced by the repository's own workflow (`.github/workflows/build-images.yaml`), which builds from the release branch and publishes to GHCR:
+
+* `obico-web` — Django/Daphne app + Celery worker
+* `obico-ml-api-cpu` — slim CPU inference image (chart default)
+* `obico-ml-api-gpu` — CUDA inference image for GPU nodes
+
+By default the chart pulls the `release` moving tag — the latest images built from the release branch at deploy time. Because that tag moves and `pullPolicy` defaults to `IfNotPresent`, already-running pods keep their pulled image until they restart. For a reproducible deployment, pin `image.*.tag`: `sha-<short>` is immutable per commit, while a CalVer like `2026.7.1` is day-granular (it moves if two commits land the same UTC day). Alternatively set the image `pullPolicy` to `Always` to re-pull on every pod start.
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| lexfrei | <f@lex.la> | <https://github.com/lexfrei> |
+
+## Source Code
+
+* <https://github.com/TheSpaghettiDetective/obico-server/>
+
+## Requirements
+
+Kubernetes: `>=1.21.0-0`
+
+## Installing the Chart
+
+```bash
+# From a checkout of this repository
+helm install obico ./charts/obico
+
+# With custom values
+helm install obico ./charts/obico --values my-values.yaml
+```
+
+## Uninstalling the Chart
+
+```bash
+helm uninstall obico
+```
+
+The data and media PVCs are annotated with `helm.sh/resource-policy: keep` and survive uninstall. Delete them manually if you no longer need the data.
+
+## Secret key (read before using GitOps)
+
+Obico needs a stable Django `SECRET_KEY`. Rotating it logs every user out and breaks signed tokens. Leaving `obico.secretKey` empty is only safe for a throwaway `helm install`: the empty-value fallback reuses the live Secret on upgrades, but **regenerates the key on every render-only path** — `helm template`, `--dry-run`, `helm diff` and ArgoCD (which renders with `helm template` and never reads the cluster). Under ArgoCD this rotates the key on every sync.
+
+For GitOps, do one of the following:
+
+```yaml
+# Set a stable key directly (e.g. openssl rand -base64 48)
+obico:
+  secretKey: "your-long-random-string"
+```
+
+```yaml
+# Or reference a Secret you manage (sealed-secrets, external-secrets, ...)
+# It must contain DJANGO_SECRET_KEY and any other sensitive env vars.
+obico:
+  existingSecret: obico-secrets
+```
+
+## Database
+
+The default configuration uses SQLite on the data volume so the chart installs with no external dependencies. **SQLite is for evaluation only:** the web server and the Celery worker are separate processes writing the same database file, so under real load they hit `database is locked` errors. Upstream Obico ships PostgreSQL only. For anything beyond a quick try-out, point `database.url` at an external PostgreSQL, reference a Secret holding the full DSN, or compose the DSN from parts with the password kept in a Secret:
+
+```yaml
+# Plain connection string
+database:
+  url: "postgresql://obico:password@postgres:5432/obico"
+```
+
+```yaml
+# Connection string from an existing Secret
+database:
+  existingSecret: obico-db
+  existingSecretKey: DATABASE_URL
+```
+
+```yaml
+# Compose the DSN from parts, with the password kept in a Secret. Point host at a
+# connection pooler (e.g. a CloudNativePG Pooler / PgBouncer) to multiplex many
+# app connections onto a few server connections. Mutually exclusive with
+# existingSecret; the password is used verbatim and must be URL-safe.
+database:
+  host: obico-db-pooler
+  port: 5432
+  name: obico
+  user: obico
+  passwordSecret: obico-db-app
+  passwordSecretKey: password
+```
+
+When `host` points at a connection pooler, run the pooler in **transaction** pooling mode, not session. Obico keeps connections open (Django `CONN_MAX_AGE=600`), so in session mode every idle connection pins one server connection and the pool is exhausted at zero query load — the app then stalls waiting for a connection that never frees. Transaction mode holds a server connection only for the duration of a transaction, so idle clients cost nothing. Obico is safe in transaction mode for the workloads this chart runs: its Channels layer runs on Redis (no PostgreSQL `LISTEN`/`NOTIFY`), and the web server and Celery worker issue no server-side cursors. (The only `QuerySet.iterator()` caller in the codebase is the `extract_prints_from_hist` management command, which this chart never runs; if you run it by hand against the pooler, expect cursor errors.) For a CloudNativePG `Pooler` this is `spec.pgbouncer.poolMode: transaction`.
+
+## Exposing the Web UI
+
+Either classic Ingress or Gateway API (HTTPRoute) can be used. Remember to set `obico.siteUsesHttps=true` when serving over HTTPS — Django 4 rejects HTTPS form posts (login, signup, admin) from untrusted origins. The chart derives `CSRF_TRUSTED_ORIGINS` automatically from the enabled ingress hosts / HTTPRoute hostnames using that scheme; override with `obico.csrfTrustedOrigins` if you front the app with a different hostname.
+
+```yaml
+# Ingress
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: obico.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: obico-tls
+      hosts:
+        - obico.example.com
+obico:
+  siteUsesHttps: true
+```
+
+```yaml
+# Gateway API
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-system
+  hostnames:
+    - obico.example.com
+obico:
+  siteUsesHttps: true
+```
+
+## Scaling notes
+
+The web pod runs a single replica because the default SQLite database lives on a ReadWriteOnce volume. It uses the `Recreate` update strategy, so every upgrade or config change tears the pod down before starting the new one — expect a brief outage on each rollout. To run multiple replicas, use an external PostgreSQL and a ReadWriteMany media volume (NFS, Longhorn RWX, CephFS, EFS, ...).
+
+## Bundled Redis
+
+The bundled Redis (`redis.enabled: true`) is a minimal, **unauthenticated** single instance intended for in-cluster use only. Do not expose it outside the cluster. For a hardened or shared Redis, set `redis.enabled: false` and point `redis.externalUrl` at your own instance.
+
+## ML inference image (CPU / GPU)
+
+The `ml-api` service ships as two images built from the same source:
+
+* **CPU (default)** — `obico-ml-api-cpu`, a slim image that runs failure detection on the CPU via ONNX Runtime. No CUDA layers and no NVIDIA toolchain, an order of magnitude smaller than the GPU image. This is what the chart deploys by default and it runs on any node.
+* **GPU** — `obico-ml-api-gpu`, the CUDA image for NVIDIA GPU inference. Much larger, since the CUDA / cuDNN runtime ships inside it.
+
+Most self-hosted deployments run CPU inference and should keep the default. Enable the GPU image only if you have an NVIDIA GPU with the device plugin configured:
+
+```yaml
+mlApi:
+  gpu: true
+  # Adjust for non-NVIDIA / MIG / time-sliced GPUs.
+  gpuResources:
+    nvidia.com/gpu: 1
+```
+
+When `gpu` is true the chart uses the CUDA image and adds `gpuResources` to the container limits, so the scheduler places the pod on a GPU node.
+
+To skip AI failure detection entirely, set `mlApi.enabled: false`. Obico still calls the ML API for any printer that has detection enabled, so when you disable the bundled ml-api either turn detection off on every printer or point `mlApi.externalHost` at an external instance — otherwise those picture uploads will error.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| database | object | `{"existingSecret":"","existingSecretKey":"DATABASE_URL","host":"","name":"","passwordSecret":"","passwordSecretKey":"password","port":5432,"url":"sqlite:////data/db.sqlite3","user":""}` | Database configuration. Defaults to SQLite on the data volume. WARNING: SQLite is for evaluation only. The server and the Celery worker run as separate processes writing the same file, so under load they will hit "database is locked" errors. Upstream ships PostgreSQL only. For any real use set url to an external postgresql:// DSN, or reference a Secret via existingSecret/existingSecretKey. |
+| database.existingSecret | string | `""` | Use a key from an existing Secret for the full DATABASE_URL instead of url |
+| database.existingSecretKey | string | `"DATABASE_URL"` | Key inside existingSecret holding the DATABASE_URL value |
+| database.host | string | `""` | PostgreSQL host. When set, DATABASE_URL is composed from the fields below and the password is injected from passwordSecret at runtime (so it never lands in the ConfigMap or in git). Mutually exclusive with existingSecret. Point this at a connection pooler service (e.g. a CloudNativePG Pooler / PgBouncer) to multiplex many app connections onto few server connections. Run the pooler in TRANSACTION mode: Obico keeps connections open (CONN_MAX_AGE=600), so session mode pins idle connections and exhausts the pool (see the Database section of the README). The password must be URL-safe; the chart does not URL-encode it. |
+| database.name | string | `""` | PostgreSQL database name (compose mode; required when host is set) |
+| database.passwordSecret | string | `""` | Name of an existing Secret holding the PostgreSQL password (compose mode; required when host is set) |
+| database.passwordSecretKey | string | `"password"` | Key inside passwordSecret holding the password |
+| database.port | int | `5432` | PostgreSQL port (compose mode) |
+| database.url | string | `"sqlite:////data/db.sqlite3"` | Database connection string (Django DATABASE_URL). Used only when neither existingSecret nor host is set. |
+| database.user | string | `""` | PostgreSQL user (compose mode; required when host is set) |
+| fullnameOverride | string | `""` |  |
+| httpRoute | object | `{"annotations":{},"enabled":false,"hostnames":["obico.example.com"],"parentRefs":[{"name":"gateway","namespace":"gateway-system"}],"rules":[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}` | HTTPRoute configuration (Gateway API) |
+| httpRoute.hostnames | list | `["obico.example.com"]` | Hostnames for the route |
+| httpRoute.parentRefs | list | `[{"name":"gateway","namespace":"gateway-system"}]` | Parent Gateway references |
+| httpRoute.rules | list | `[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Routing rules |
+| image | object | `{"mlApi":{"cpu":{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-cpu","tag":""},"gpu":{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-gpu","tag":""},"pullPolicy":"IfNotPresent"},"web":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/thespaghettidetective/obico-web","tag":""}}` | Container images. Built from obico-server source by the in-repo workflow (.github/workflows/build-images.yaml) and published to GHCR under the repository owner's namespace (ghcr.io/thespaghettidetective/* upstream). Each tag defaults to the "release" moving tag the workflow publishes on the release branch; pin a specific tag (a CalVer like 2026.7.1 or sha-<short>) for reproducibility. |
+| image.mlApi | object | `{"cpu":{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-cpu","tag":""},"gpu":{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-gpu","tag":""},"pullPolicy":"IfNotPresent"}` | ML inference API images. Two variants are published from the same source: a slim CPU-only image (default) and a CUDA image for GPU inference. mlApi.gpu selects which one runs; configure each variant independently. |
+| image.mlApi.cpu | object | `{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-cpu","tag":""}` | CPU-only inference image (slim). Used when mlApi.gpu is false. |
+| image.mlApi.cpu.tag | string | `""` | Overrides the CPU image tag whose default is the "release" moving tag |
+| image.mlApi.gpu | object | `{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-gpu","tag":""}` | CUDA inference image (large). Used when mlApi.gpu is true. |
+| image.mlApi.gpu.tag | string | `""` | Overrides the GPU image tag whose default is the "release" moving tag |
+| image.web | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/thespaghettidetective/obico-web","tag":""}` | Web application image (Django + Celery) |
+| image.web.tag | string | `""` | Overrides the image tag whose default is the "release" moving tag |
+| imagePullSecrets | list | `[]` |  |
+| ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"obico.example.com","paths":[{"path":"/","pathType":"Prefix"}]}],"tls":[{"hosts":["obico.example.com"],"secretName":"obico-tls"}]}` | Ingress configuration |
+| mlApi | object | `{"command":["gunicorn","--bind=0.0.0.0:3333","--workers=1","--access-logfile=-","wsgi"],"enabled":true,"externalHost":"","gpu":false,"gpuResources":{"nvidia.com/gpu":1},"replicaCount":1,"resources":{"limits":{"cpu":"2","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}},"securityContext":{}}` | ML inference API (AI failure detection). Can be disabled. |
+| mlApi.command | list | `["gunicorn","--bind=0.0.0.0:3333","--workers=1","--access-logfile=-","wsgi"]` | Command for the gunicorn inference server |
+| mlApi.enabled | bool | `true` | Deploy the ML inference API |
+| mlApi.externalHost | string | `""` | External ML inference API URL, used when enabled is false. Obico still calls the ML API for prints that have AI detection on, so if you disable the bundled ml-api, either point this at an external instance (e.g. http://ml-api:3333) or make sure AI detection is off on every printer — otherwise picture uploads that request detection will error. |
+| mlApi.gpu | bool | `false` | Run the CUDA (GPU) inference image instead of the slim CPU default. When true the ml-api container uses image.mlApi.gpu and requests the accelerator from gpuResources; requires an NVIDIA GPU and device plugin on the node. The CPU image works everywhere and is far smaller, so leave this false unless you actually have a GPU. |
+| mlApi.gpuResources | object | `{"nvidia.com/gpu":1}` | Accelerator resources merged into the ml-api container limits when gpu is true. Adjust for non-NVIDIA or MIG / time-sliced GPUs (e.g. nvidia.com/mig-1g.5gb: 1). |
+| mlApi.replicaCount | int | `1` | Number of ml-api replicas |
+| mlApi.resources | object | `{"limits":{"cpu":"2","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Resource requests/limits for the ml-api container |
+| mlApi.securityContext | object | `{}` | Security context for the ml-api container. Left empty (image default = root) because the upstream CUDA-based ml-api image is not validated to run unprivileged (model cache and runtime expect root). Harden here once confirmed it runs as non-root in your environment. |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| obico | object | `{"csrfTrustedOrigins":[],"debug":false,"existingSecret":"","extraEnv":{},"extraSecretEnv":{},"secretKey":"","siteUsesHttps":false}` | Obico application configuration (rendered into the env ConfigMap/Secret) |
+| obico.csrfTrustedOrigins | list | `[]` | CSRF trusted origins (Django 4+ rejects HTTPS POSTs from untrusted origins). Leave empty to auto-derive from the enabled ingress hosts / HTTPRoute hostnames using the scheme implied by siteUsesHttps. Set explicitly to override, e.g. ["https://obico.example.com"]. |
+| obico.debug | bool | `false` | Enable Django debug mode (never enable in production) |
+| obico.existingSecret | string | `""` | Reference a pre-created Secret for sensitive env (must contain DJANGO_SECRET_KEY and any other secret keys). When set, the chart does not create its own Secret and extraSecretEnv is ignored. Recommended for GitOps. |
+| obico.extraEnv | object | `{}` | Extra non-sensitive environment variables (key/value) for web and tasks. Chart-managed keys (DATABASE_URL, REDIS_URL, ...) are rejected here. Example: EMAIL_HOST: smtp.example.com |
+| obico.extraSecretEnv | object | `{}` | Extra sensitive environment variables (key/value) stored in the Secret. Example: EMAIL_HOST_PASSWORD: s3cr3t |
+| obico.secretKey | string | `""` | Django SECRET_KEY. IMPORTANT: leave empty only for a quick `helm install` test. The empty-value fallback reuses the live Secret on upgrades but REGENERATES the key on any render-only path (helm template, --dry-run, helm diff, ArgoCD) — rotating it logs every user out and rolls the pod on every sync. For GitOps set a stable value here (e.g. `openssl rand -base64 48`) or use existingSecret below. |
+| obico.siteUsesHttps | bool | `false` | Set to true when the site is served over HTTPS (behind a TLS ingress/gateway) |
+| persistence | object | `{"data":{"accessMode":"ReadWriteOnce","enabled":true,"existingClaim":"","retain":true,"size":"1Gi","storageClassName":""},"media":{"accessMode":"ReadWriteOnce","enabled":true,"existingClaim":"","retain":true,"size":"10Gi","storageClassName":""}}` | Persistence configuration |
+| persistence.data | object | `{"accessMode":"ReadWriteOnce","enabled":true,"existingClaim":"","retain":true,"size":"1Gi","storageClassName":""}` | Data volume (SQLite database and persistent data) |
+| persistence.data.accessMode | string | `"ReadWriteOnce"` | Access mode |
+| persistence.data.existingClaim | string | `""` | Use an existing PVC instead of creating one |
+| persistence.data.retain | bool | `true` | Keep the PVC when the release is uninstalled |
+| persistence.data.size | string | `"1Gi"` | Size of the volume |
+| persistence.data.storageClassName | string | `""` | Storage class name |
+| persistence.media | object | `{"accessMode":"ReadWriteOnce","enabled":true,"existingClaim":"","retain":true,"size":"10Gi","storageClassName":""}` | Media volume (user uploads, webcam frames, timelapses) |
+| persistence.media.accessMode | string | `"ReadWriteOnce"` | Access mode |
+| persistence.media.existingClaim | string | `""` | Use an existing PVC instead of creating one |
+| persistence.media.retain | bool | `true` | Keep the PVC when the release is uninstalled |
+| persistence.media.size | string | `"10Gi"` | Size of the volume |
+| persistence.media.storageClassName | string | `""` | Storage class name |
+| podAnnotations | object | `{}` | Pod annotations |
+| podLabels | object | `{}` | Pod labels |
+| podSecurityContext | object | `{"fsGroup":65534}` | Security context for the pod. fsGroup is load-bearing, not cosmetic: the server, tasks and migrate containers run as non-root (65534, see securityContext below), so the data and media volumes must be group-owned by that gid for them to write the SQLite DB and media files. It also lets the non-root server read the static assets generated by the root collectstatic init container. Keep them aligned. |
+| redis | object | `{"enabled":true,"externalUrl":"","image":{"pullPolicy":"IfNotPresent","repository":"redis","tag":"8.8-alpine"},"resources":{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"50m","memory":"64Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":999}}` | Bundled Redis (Celery broker + Django Channels + cache) |
+| redis.enabled | bool | `true` | Deploy a minimal in-cluster Redis. Disable to use an external Redis. |
+| redis.externalUrl | string | `""` | External Redis URL, used when redis.enabled is false |
+| redis.image | object | `{"pullPolicy":"IfNotPresent","repository":"redis","tag":"8.8-alpine"}` | Redis image (pinned; not tied to the chart appVersion) |
+| redis.resources | object | `{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | Resource requests/limits for the redis container |
+| redis.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":999}` | Security context for the redis container |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | Security context for the server, tasks and migrate containers |
+| service | object | `{"mlApi":{"annotations":{},"port":3333,"type":"ClusterIP"},"web":{"annotations":{},"port":3334,"type":"ClusterIP"}}` | Service configuration |
+| service.mlApi | object | `{"annotations":{},"port":3333,"type":"ClusterIP"}` | ML inference API service (internal) |
+| service.mlApi.annotations | object | `{}` | Annotations for the ml-api service |
+| service.mlApi.port | int | `3333` | HTTP port |
+| service.mlApi.type | string | `"ClusterIP"` | Service type for the ml-api |
+| service.web | object | `{"annotations":{},"port":3334,"type":"ClusterIP"}` | Web UI / API service (ClusterIP for Ingress/HTTPRoute) |
+| service.web.annotations | object | `{}` | Annotations for the web service |
+| service.web.port | int | `3334` | HTTP port |
+| service.web.type | string | `"ClusterIP"` | Service type for the web UI |
+| serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | Service account configuration |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use |
+| tasks | object | `{"command":["celery","-A","config","worker","--beat","--schedule","/data/celerybeat-schedule","-l","info","-c","2","-Q","realtime,celery"],"resources":{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}}` | Celery worker (runs in the same pod as the web server) |
+| tasks.command | list | `["celery","-A","config","worker","--beat","--schedule","/data/celerybeat-schedule","-l","info","-c","2","-Q","realtime,celery"]` | Command for the Celery worker with the embedded beat scheduler. The beat schedule DB is written under /data (a writable, persistent volume) because the container runs as non-root and the image's /app is not writable; the default (celerybeat-schedule in the working directory) would crash beat. |
+| tasks.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resource requests/limits for the tasks container |
+| tolerations | list | `[]` |  |
+| web | object | `{"command":["daphne","-b","0.0.0.0","-p","3334","config.routing:application"],"resources":{"limits":{"cpu":"1","memory":"1Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}}` | Web pod configuration (server + tasks containers, plus init containers) |
+| web.command | list | `["daphne","-b","0.0.0.0","-p","3334","config.routing:application"]` | Command for the Daphne ASGI server (serves API, frontend and websockets) |
+| web.resources | object | `{"limits":{"cpu":"1","memory":"1Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Resource requests/limits for the server container |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/obico/README.md.gotmpl
+++ b/charts/obico/README.md.gotmpl
@@ -1,0 +1,174 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## About
+
+[Obico](https://www.obico.io/) (formerly The Spaghetti Detective) is a self-hosted server that adds remote access, webcam streaming and AI-powered failure detection to OctoPrint and Klipper 3D printers.
+
+This chart deploys the full stack:
+
+* **web** — Django application served by Daphne (API, frontend, websockets)
+* **tasks** — Celery worker + beat scheduler (runs in the same pod as web)
+* **ml-api** — Flask/Gunicorn AI inference service for print-failure detection
+* **redis** — bundled Celery broker / Django Channels layer / cache
+
+## Images
+
+Obico's docker-compose builds the server images from source. This chart consumes prebuilt, tagged equivalents produced by the repository's own workflow (`.github/workflows/build-images.yaml`), which builds from the release branch and publishes to GHCR:
+
+* `obico-web` — Django/Daphne app + Celery worker
+* `obico-ml-api-cpu` — slim CPU inference image (chart default)
+* `obico-ml-api-gpu` — CUDA inference image for GPU nodes
+
+By default the chart pulls the `release` moving tag — the latest images built from the release branch at deploy time. Because that tag moves and `pullPolicy` defaults to `IfNotPresent`, already-running pods keep their pulled image until they restart. For a reproducible deployment, pin `image.*.tag`: `sha-<short>` is immutable per commit, while a CalVer like `2026.7.1` is day-granular (it moves if two commits land the same UTC day). Alternatively set the image `pullPolicy` to `Always` to re-pull on every pod start.
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Installing the Chart
+
+```bash
+# From a checkout of this repository
+helm install obico ./charts/obico
+
+# With custom values
+helm install obico ./charts/obico --values my-values.yaml
+```
+
+## Uninstalling the Chart
+
+```bash
+helm uninstall obico
+```
+
+The data and media PVCs are annotated with `helm.sh/resource-policy: keep` and survive uninstall. Delete them manually if you no longer need the data.
+
+## Secret key (read before using GitOps)
+
+Obico needs a stable Django `SECRET_KEY`. Rotating it logs every user out and breaks signed tokens. Leaving `obico.secretKey` empty is only safe for a throwaway `helm install`: the empty-value fallback reuses the live Secret on upgrades, but **regenerates the key on every render-only path** — `helm template`, `--dry-run`, `helm diff` and ArgoCD (which renders with `helm template` and never reads the cluster). Under ArgoCD this rotates the key on every sync.
+
+For GitOps, do one of the following:
+
+```yaml
+# Set a stable key directly (e.g. openssl rand -base64 48)
+obico:
+  secretKey: "your-long-random-string"
+```
+
+```yaml
+# Or reference a Secret you manage (sealed-secrets, external-secrets, ...)
+# It must contain DJANGO_SECRET_KEY and any other sensitive env vars.
+obico:
+  existingSecret: obico-secrets
+```
+
+## Database
+
+The default configuration uses SQLite on the data volume so the chart installs with no external dependencies. **SQLite is for evaluation only:** the web server and the Celery worker are separate processes writing the same database file, so under real load they hit `database is locked` errors. Upstream Obico ships PostgreSQL only. For anything beyond a quick try-out, point `database.url` at an external PostgreSQL, reference a Secret holding the full DSN, or compose the DSN from parts with the password kept in a Secret:
+
+```yaml
+# Plain connection string
+database:
+  url: "postgresql://obico:password@postgres:5432/obico"
+```
+
+```yaml
+# Connection string from an existing Secret
+database:
+  existingSecret: obico-db
+  existingSecretKey: DATABASE_URL
+```
+
+```yaml
+# Compose the DSN from parts, with the password kept in a Secret. Point host at a
+# connection pooler (e.g. a CloudNativePG Pooler / PgBouncer) to multiplex many
+# app connections onto a few server connections. Mutually exclusive with
+# existingSecret; the password is used verbatim and must be URL-safe.
+database:
+  host: obico-db-pooler
+  port: 5432
+  name: obico
+  user: obico
+  passwordSecret: obico-db-app
+  passwordSecretKey: password
+```
+
+When `host` points at a connection pooler, run the pooler in **transaction** pooling mode, not session. Obico keeps connections open (Django `CONN_MAX_AGE=600`), so in session mode every idle connection pins one server connection and the pool is exhausted at zero query load — the app then stalls waiting for a connection that never frees. Transaction mode holds a server connection only for the duration of a transaction, so idle clients cost nothing. Obico is safe in transaction mode for the workloads this chart runs: its Channels layer runs on Redis (no PostgreSQL `LISTEN`/`NOTIFY`), and the web server and Celery worker issue no server-side cursors. (The only `QuerySet.iterator()` caller in the codebase is the `extract_prints_from_hist` management command, which this chart never runs; if you run it by hand against the pooler, expect cursor errors.) For a CloudNativePG `Pooler` this is `spec.pgbouncer.poolMode: transaction`.
+
+## Exposing the Web UI
+
+Either classic Ingress or Gateway API (HTTPRoute) can be used. Remember to set `obico.siteUsesHttps=true` when serving over HTTPS — Django 4 rejects HTTPS form posts (login, signup, admin) from untrusted origins. The chart derives `CSRF_TRUSTED_ORIGINS` automatically from the enabled ingress hosts / HTTPRoute hostnames using that scheme; override with `obico.csrfTrustedOrigins` if you front the app with a different hostname.
+
+```yaml
+# Ingress
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: obico.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: obico-tls
+      hosts:
+        - obico.example.com
+obico:
+  siteUsesHttps: true
+```
+
+```yaml
+# Gateway API
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-system
+  hostnames:
+    - obico.example.com
+obico:
+  siteUsesHttps: true
+```
+
+## Scaling notes
+
+The web pod runs a single replica because the default SQLite database lives on a ReadWriteOnce volume. It uses the `Recreate` update strategy, so every upgrade or config change tears the pod down before starting the new one — expect a brief outage on each rollout. To run multiple replicas, use an external PostgreSQL and a ReadWriteMany media volume (NFS, Longhorn RWX, CephFS, EFS, ...).
+
+## Bundled Redis
+
+The bundled Redis (`redis.enabled: true`) is a minimal, **unauthenticated** single instance intended for in-cluster use only. Do not expose it outside the cluster. For a hardened or shared Redis, set `redis.enabled: false` and point `redis.externalUrl` at your own instance.
+
+## ML inference image (CPU / GPU)
+
+The `ml-api` service ships as two images built from the same source:
+
+* **CPU (default)** — `obico-ml-api-cpu`, a slim image that runs failure detection on the CPU via ONNX Runtime. No CUDA layers and no NVIDIA toolchain, an order of magnitude smaller than the GPU image. This is what the chart deploys by default and it runs on any node.
+* **GPU** — `obico-ml-api-gpu`, the CUDA image for NVIDIA GPU inference. Much larger, since the CUDA / cuDNN runtime ships inside it.
+
+Most self-hosted deployments run CPU inference and should keep the default. Enable the GPU image only if you have an NVIDIA GPU with the device plugin configured:
+
+```yaml
+mlApi:
+  gpu: true
+  # Adjust for non-NVIDIA / MIG / time-sliced GPUs.
+  gpuResources:
+    nvidia.com/gpu: 1
+```
+
+When `gpu` is true the chart uses the CUDA image and adds `gpuResources` to the container limits, so the scheduler places the pod on a GPU node.
+
+To skip AI failure detection entirely, set `mlApi.enabled: false`. Obico still calls the ML API for any printer that has detection enabled, so when you disable the bundled ml-api either turn detection off on every printer or point `mlApi.externalHost` at an external instance — otherwise those picture uploads will error.
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/obico/templates/NOTES.txt
+++ b/charts/obico/templates/NOTES.txt
@@ -1,0 +1,66 @@
+Thank you for installing {{ .Chart.Name }}!
+
+Obico server has been deployed.
+
+Release Name: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+
+Components:
+  - web (Django + Daphne) and tasks (Celery) in one pod
+  {{- if .Values.mlApi.enabled }}
+  - ml-api (AI failure detection)
+  {{- end }}
+  {{- if .Values.redis.enabled }}
+  - redis (bundled)
+  {{- end }}
+
+Database: {{ if .Values.database.existingSecret }}external (full DSN from secret {{ .Values.database.existingSecret }}){{ else if .Values.database.host }}postgresql://{{ .Values.database.user }}@{{ .Values.database.host }}:{{ .Values.database.port }}/{{ .Values.database.name }} (password from secret {{ .Values.database.passwordSecret }}){{ else }}{{ .Values.database.url }}{{ end }}
+
+To check the status of your deployment:
+
+  kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ include "obico.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
+
+{{- if .Values.ingress.enabled }}
+
+Web UI is accessible at:
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  - http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if .Values.httpRoute.enabled }}
+
+Web UI is accessible at:
+{{- range .Values.httpRoute.hostnames }}
+  - https://{{ . }}
+{{- end }}
+{{- else }}
+
+To access the Web UI, forward the port:
+
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "obico.fullname" . }}-web {{ .Values.service.web.port }}:{{ .Values.service.web.port }}
+
+Then open: http://localhost:{{ .Values.service.web.port }}
+{{- end }}
+
+First-run setup:
+  1. Create an admin account (self-service signup is disabled by default):
+
+       kubectl --namespace {{ .Release.Namespace }} exec -it \
+         deploy/{{ include "obico.fullname" . }}-web -c server -- \
+         python manage.py createsuperuser
+
+     To allow open registration instead, set
+     obico.extraEnv.ACCOUNT_ALLOW_SIGN_UP="True".
+  2. Configure the public URL under Settings if serving behind a proxy.
+{{- if not .Values.obico.siteUsesHttps }}
+  3. When serving over HTTPS, set obico.siteUsesHttps=true and upgrade.
+{{- end }}
+
+To view logs:
+
+  kubectl --namespace {{ .Release.Namespace }} logs -l "app.kubernetes.io/name={{ include "obico.name" . }},app.kubernetes.io/component=web" --tail=100 -f
+
+For more information:
+  - Chart: https://github.com/TheSpaghettiDetective/obico-server/tree/release/charts/obico
+  - Obico: https://www.obico.io/

--- a/charts/obico/templates/_helpers.tpl
+++ b/charts/obico/templates/_helpers.tpl
@@ -1,0 +1,216 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "obico.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+Truncate at 56, not 63: templates append component suffixes (the longest is
+"-ml-api", 7 chars) to this base name, and the result must stay within the
+63-char Kubernetes DNS label limit. If the release name contains the chart
+name it is used as the full name.
+*/}}
+{{- define "obico.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 56 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 56 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 56 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "obico.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "obico.labels" -}}
+helm.sh/chart: {{ include "obico.chart" . }}
+{{ include "obico.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels (shared across all components).
+Per-component templates add app.kubernetes.io/component to disambiguate pods.
+*/}}
+{{- define "obico.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "obico.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "obico.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "obico.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the Redis URL: bundled service when redis.enabled, otherwise external.
+*/}}
+{{- define "obico.redisUrl" -}}
+{{- if .Values.redis.enabled -}}
+redis://{{ include "obico.fullname" . }}-redis:6379/0
+{{- else if .Values.redis.externalUrl -}}
+{{- .Values.redis.externalUrl -}}
+{{- else -}}
+{{- fail "redis.enabled is false: set redis.externalUrl to an external Redis connection string" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Name of the Secret holding sensitive env (DJANGO_SECRET_KEY, ...).
+Use a pre-created Secret when obico.existingSecret is set, otherwise the
+chart-managed Secret named after the release.
+*/}}
+{{- define "obico.secretName" -}}
+{{- if .Values.obico.existingSecret -}}
+{{- .Values.obico.existingSecret -}}
+{{- else -}}
+{{- include "obico.fullname" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolve the Django SECRET_KEY for the chart-managed Secret.
+Prefer an explicit value; otherwise reuse the key from an existing Secret so it
+stays stable across live upgrades; otherwise generate a new random key.
+NOTE: the lookup-based reuse only works during a live `helm install/upgrade`.
+Render-only paths (helm template, --dry-run, helm diff, ArgoCD) cannot read the
+cluster, so they regenerate the key on every render. For GitOps set
+obico.secretKey explicitly or use obico.existingSecret.
+*/}}
+{{- define "obico.secretKey" -}}
+{{- if .Values.obico.secretKey -}}
+{{- .Values.obico.secretKey -}}
+{{- else -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "obico.fullname" .) -}}
+{{- if and $existing $existing.data (index $existing.data "DJANGO_SECRET_KEY") -}}
+{{- index $existing.data "DJANGO_SECRET_KEY" | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 50 -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+JSON-encoded CSRF_TRUSTED_ORIGINS for Django. Django 4+ rejects HTTPS POSTs
+(login, signup, admin) whose origin is not listed here. Use an explicit
+obico.csrfTrustedOrigins list when set; otherwise derive origins from the
+ingress hosts and HTTPRoute hostnames, using the scheme implied by
+obico.siteUsesHttps.
+*/}}
+{{- define "obico.csrfTrustedOrigins" -}}
+{{- $scheme := ternary "https" "http" .Values.obico.siteUsesHttps -}}
+{{- $origins := list -}}
+{{- if .Values.obico.csrfTrustedOrigins -}}
+{{- $origins = .Values.obico.csrfTrustedOrigins -}}
+{{- else -}}
+{{- if .Values.ingress.enabled -}}
+{{- range .Values.ingress.hosts -}}
+{{- $origins = append $origins (printf "%s://%s" $scheme .host) -}}
+{{- end -}}
+{{- end -}}
+{{- if .Values.httpRoute.enabled -}}
+{{- range .Values.httpRoute.hostnames -}}
+{{- $origins = append $origins (printf "%s://%s" $scheme .) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $origins | toJson -}}
+{{- end }}
+
+{{/*
+Shared environment wiring for every web-image container (collectstatic, migrate,
+server, tasks). Keeping it in one place guarantees the containers stay identical
+by construction — e.g. the DATABASE_URL override is never accidentally dropped
+from one of them.
+*/}}
+{{- define "obico.podEnv" -}}
+envFrom:
+  - configMapRef:
+      name: {{ include "obico.fullname" . }}
+  - secretRef:
+      name: {{ include "obico.secretName" . }}
+{{- if .Values.database.existingSecret }}
+env:
+  - name: DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.database.existingSecret }}
+        key: {{ .Values.database.existingSecretKey }}
+{{- else if .Values.database.host }}
+env:
+  # OBICO_DB_PASSWORD is read from the Secret, then referenced via the $(VAR)
+  # dependent-env syntax so the password is assembled into DATABASE_URL at
+  # runtime instead of being baked into the ConfigMap. Kubernetes only expands
+  # $(VAR) for vars declared earlier in the same container's env list.
+  - name: OBICO_DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.database.passwordSecret }}
+        key: {{ .Values.database.passwordSecretKey }}
+  - name: DATABASE_URL
+    value: {{ printf "postgresql://%s:$(OBICO_DB_PASSWORD)@%s:%v/%s" .Values.database.user .Values.database.host .Values.database.port .Values.database.name | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Validate the database configuration. existingSecret (full DSN from a Secret) and
+host (DATABASE_URL composed from parts) are mutually exclusive; compose mode
+requires user, name and passwordSecret. Rendered once from configmap.yaml.
+*/}}
+{{- define "obico.validateDatabase" -}}
+{{- if and .Values.database.existingSecret .Values.database.host -}}
+{{- fail "database.existingSecret and database.host are mutually exclusive: set one or the other" -}}
+{{- end -}}
+{{- if .Values.database.host -}}
+{{- if not .Values.database.user -}}
+{{- fail "database.host is set: database.user is required to compose DATABASE_URL" -}}
+{{- end -}}
+{{- if not .Values.database.name -}}
+{{- fail "database.host is set: database.name is required to compose DATABASE_URL" -}}
+{{- end -}}
+{{- if not .Values.database.passwordSecret -}}
+{{- fail "database.host is set: database.passwordSecret is required to source the password" -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Guard against overriding chart-managed environment variables through the
+free-form extraEnv / extraSecretEnv maps, which would silently win via
+later-key YAML semantics in the ConfigMap / Secret.
+*/}}
+{{- define "obico.checkReservedEnv" -}}
+{{- $reserved := list "DEBUG" "WEBPACK_LOADER_ENABLED" "SITE_USES_HTTPS" "REDIS_URL" "ML_API_HOST" "INTERNAL_MEDIA_HOST" "DATABASE_URL" "OBICO_DB_PASSWORD" "DJANGO_SECRET_KEY" "CSRF_TRUSTED_ORIGINS" -}}
+{{- range $key, $_ := .Values.obico.extraEnv -}}
+{{- if has $key $reserved -}}
+{{- fail (printf "obico.extraEnv must not set the chart-managed key %q; configure it via its dedicated value instead" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- range $key, $_ := .Values.obico.extraSecretEnv -}}
+{{- if has $key $reserved -}}
+{{- fail (printf "obico.extraSecretEnv must not set the chart-managed key %q; configure it via its dedicated value instead" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/charts/obico/templates/configmap.yaml
+++ b/charts/obico/templates/configmap.yaml
@@ -1,0 +1,26 @@
+{{- include "obico.checkReservedEnv" . -}}
+{{- include "obico.validateDatabase" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "obico.fullname" . }}
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+data:
+  DEBUG: {{ ternary "True" "False" .Values.obico.debug | quote }}
+  WEBPACK_LOADER_ENABLED: "False"
+  SITE_USES_HTTPS: {{ ternary "True" "False" .Values.obico.siteUsesHttps | quote }}
+  CSRF_TRUSTED_ORIGINS: {{ include "obico.csrfTrustedOrigins" . | quote }}
+  REDIS_URL: {{ include "obico.redisUrl" . | quote }}
+  {{- if .Values.mlApi.enabled }}
+  ML_API_HOST: {{ printf "http://%s-ml-api:%v" (include "obico.fullname" .) .Values.service.mlApi.port | quote }}
+  {{- else if .Values.mlApi.externalHost }}
+  ML_API_HOST: {{ .Values.mlApi.externalHost | quote }}
+  {{- end }}
+  INTERNAL_MEDIA_HOST: {{ printf "http://%s-web:%v" (include "obico.fullname" .) .Values.service.web.port | quote }}
+  {{- if and (not .Values.database.existingSecret) (not .Values.database.host) }}
+  DATABASE_URL: {{ .Values.database.url | quote }}
+  {{- end }}
+  {{- range $key, $value := .Values.obico.extraEnv }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/charts/obico/templates/deployment-ml-api.yaml
+++ b/charts/obico/templates/deployment-ml-api.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.mlApi.enabled }}
+{{- $mlImage := ternary .Values.image.mlApi.gpu .Values.image.mlApi.cpu .Values.mlApi.gpu -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "obico.fullname" . }}-ml-api
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ml-api
+spec:
+  replicas: {{ .Values.mlApi.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "obico.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ml-api
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "obico.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: ml-api
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "obico.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      containers:
+        - name: ml-api
+          image: "{{ $mlImage.repository }}:{{ $mlImage.tag | default "release" }}"
+          imagePullPolicy: {{ .Values.image.mlApi.pullPolicy }}
+          {{- with .Values.mlApi.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            {{- toYaml .Values.mlApi.command | nindent 12 }}
+          env:
+            - name: FLASK_APP
+              value: server.py
+          ports:
+            - name: http
+              containerPort: 3333
+              protocol: TCP
+          # Cheap socket check for liveness; readiness uses /hc/.
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /hc/
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            {{- $resources := deepCopy .Values.mlApi.resources }}
+            {{- if .Values.mlApi.gpu }}
+            {{- $limits := $resources.limits | default dict }}
+            {{- range $name, $qty := .Values.mlApi.gpuResources }}
+            {{- $_ := set $limits $name $qty }}
+            {{- end }}
+            {{- $_ := set $resources "limits" $limits }}
+            {{- end }}
+            {{- toYaml $resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/obico/templates/deployment-web.yaml
+++ b/charts/obico/templates/deployment-web.yaml
@@ -1,0 +1,188 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "obico.fullname" . }}-web
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  # SQLite on a ReadWriteOnce volume allows only a single writer. Scaling the
+  # web pod requires an external PostgreSQL and a ReadWriteMany media volume.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "obico.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "obico.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "obico.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: collectstatic
+          image: "{{ .Values.image.web.repository }}:{{ .Values.image.web.tag | default "release" }}"
+          imagePullPolicy: {{ .Values.image.web.pullPolicy }}
+          # Generates static assets into the shared static volume. Runs as root
+          # because the image's /app tree is owned by root, but still drops
+          # capabilities and blocks privilege escalation for defense in depth.
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - python
+            - manage.py
+            - collectstatic
+            - -v
+            - "2"
+            - --noinput
+          {{- include "obico.podEnv" . | nindent 10 }}
+          volumeMounts:
+            - name: static
+              mountPath: /app/static_build
+        - name: migrate
+          image: "{{ .Values.image.web.repository }}:{{ .Values.image.web.tag | default "release" }}"
+          imagePullPolicy: {{ .Values.image.web.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - python
+            - manage.py
+            - migrate
+            - --noinput
+          {{- include "obico.podEnv" . | nindent 10 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      containers:
+        - name: server
+          image: "{{ .Values.image.web.repository }}:{{ .Values.image.web.tag | default "release" }}"
+          imagePullPolicy: {{ .Values.image.web.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            {{- toYaml .Values.web.command | nindent 12 }}
+          {{- include "obico.podEnv" . | nindent 10 }}
+          ports:
+            - name: http
+              containerPort: 3334
+              protocol: TCP
+          # Liveness is a cheap socket check: the /hc/ endpoint queries the DB
+          # and Redis, so using it for liveness would restart the pod on any
+          # transient dependency blip. Readiness uses /hc/ to pull the pod out
+          # of the Service until its dependencies are back.
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /hc/
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          # static (emptyDir) holds collectstatic output; media (PVC) is mounted
+          # nested at static_build/media so user uploads land on the PVC while
+          # static assets stay in the emptyDir. The parent (static) is listed
+          # before the nested child (media) so the media PVC is never shadowed by
+          # the static emptyDir, regardless of how the runtime orders the mounts.
+          # collectstatic writes only static, so nothing it produces is shadowed
+          # by the media PVC. The tasks container does not serve static and so
+          # does not mount it.
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: static
+              mountPath: /app/static_build
+            - name: media
+              mountPath: /app/static_build/media
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+        # Celery worker. Intentionally has no liveness probe: it shares this pod
+        # with the server container, so a flaky `celery inspect ping` would
+        # restart the whole pod (including a healthy server). Worker health is
+        # observed via logs/metrics instead.
+        - name: tasks
+          image: "{{ .Values.image.web.repository }}:{{ .Values.image.web.tag | default "release" }}"
+          imagePullPolicy: {{ .Values.image.web.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            {{- toYaml .Values.tasks.command | nindent 12 }}
+          {{- include "obico.podEnv" . | nindent 10 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: media
+              mountPath: /app/static_build/media
+          resources:
+            {{- toYaml .Values.tasks.resources | nindent 12 }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.data.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.data.existingClaim }}
+          {{- else if .Values.persistence.data.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "obico.fullname" . }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: media
+          {{- if .Values.persistence.media.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.media.existingClaim }}
+          {{- else if .Values.persistence.media.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "obico.fullname" . }}-media
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: static
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/obico/templates/httproute.yaml
+++ b/charts/obico/templates/httproute.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "obico.fullname" . }}
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    -
+      {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "obico.fullname" $ }}-web
+          port: {{ $.Values.service.web.port }}
+          {{- if not (kindIs "invalid" .weight) }}
+          weight: {{ .weight }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/obico/templates/ingress.yaml
+++ b/charts/obico/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "obico.fullname" . }}
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "obico.fullname" $ }}-web
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/obico/templates/pvc-data.yaml
+++ b/charts/obico/templates/pvc-data.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.data.enabled (not .Values.persistence.data.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "obico.fullname" . }}-data
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+  {{- if .Values.persistence.data.retain }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.data.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size }}
+  {{- if .Values.persistence.data.storageClassName }}
+  storageClassName: {{ .Values.persistence.data.storageClassName }}
+  {{- end }}
+{{- end }}

--- a/charts/obico/templates/pvc-media.yaml
+++ b/charts/obico/templates/pvc-media.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.media.enabled (not .Values.persistence.media.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "obico.fullname" . }}-media
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+  {{- if .Values.persistence.media.retain }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.media.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.media.size }}
+  {{- if .Values.persistence.media.storageClassName }}
+  storageClassName: {{ .Values.persistence.media.storageClassName }}
+  {{- end }}
+{{- end }}

--- a/charts/obico/templates/redis.yaml
+++ b/charts/obico/templates/redis.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "obico.fullname" . }}-redis
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "obico.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "obico.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          {{- with .Values.redis.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "obico.fullname" . }}-redis
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: redis
+      protocol: TCP
+      name: redis
+  selector:
+    {{- include "obico.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+{{- end }}

--- a/charts/obico/templates/secret.yaml
+++ b/charts/obico/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.obico.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "obico.fullname" . }}
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  DJANGO_SECRET_KEY: {{ include "obico.secretKey" . | quote }}
+  {{- range $key, $value := .Values.obico.extraSecretEnv }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/obico/templates/service.yaml
+++ b/charts/obico/templates/service.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "obico.fullname" . }}-web
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+  {{- with .Values.service.web.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.web.type }}
+  ports:
+    - port: {{ .Values.service.web.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "obico.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+{{- if .Values.mlApi.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "obico.fullname" . }}-ml-api
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ml-api
+  {{- with .Values.service.mlApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.mlApi.type }}
+  ports:
+    - port: {{ .Values.service.mlApi.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "obico.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ml-api
+{{- end }}

--- a/charts/obico/templates/serviceaccount.yaml
+++ b/charts/obico/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "obico.serviceAccountName" . }}
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/obico/tests/chart_test.yaml
+++ b/charts/obico/tests/chart_test.yaml
@@ -1,0 +1,60 @@
+suite: test obico chart
+templates:
+  - deployment-web.yaml
+  - deployment-ml-api.yaml
+  - service.yaml
+  - serviceaccount.yaml
+  - configmap.yaml
+  - secret.yaml
+  - pvc-data.yaml
+  - pvc-media.yaml
+tests:
+  - it: should render all default resources
+    asserts:
+      - isKind:
+          of: Deployment
+        template: deployment-web.yaml
+      - isKind:
+          of: Deployment
+        template: deployment-ml-api.yaml
+      - isKind:
+          of: ServiceAccount
+        template: serviceaccount.yaml
+      - isKind:
+          of: ConfigMap
+        template: configmap.yaml
+      - isKind:
+          of: Secret
+        template: secret.yaml
+      - isKind:
+          of: PersistentVolumeClaim
+        template: pvc-data.yaml
+      - isKind:
+          of: PersistentVolumeClaim
+        template: pvc-media.yaml
+
+  - it: should default the web image to the release moving tag
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/thespaghettidetective/obico-web:release
+
+  - it: should let image.web.tag pin a specific version
+    template: deployment-web.yaml
+    set:
+      image.web.tag: "2026.7.1"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/thespaghettidetective/obico-web:2026.7.1
+
+  - it: should include standard labels on the web deployment
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: obico
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm

--- a/charts/obico/tests/configmap_test.yaml
+++ b/charts/obico/tests/configmap_test.yaml
@@ -1,0 +1,219 @@
+suite: test env configmap
+templates:
+  - configmap.yaml
+tests:
+  - it: should create a ConfigMap
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico
+
+  - it: should default DATABASE_URL to SQLite
+    asserts:
+      - equal:
+          path: data.DATABASE_URL
+          value: "sqlite:////data/db.sqlite3"
+
+  - it: should point REDIS_URL at the bundled redis
+    asserts:
+      - equal:
+          path: data.REDIS_URL
+          value: "redis://RELEASE-NAME-obico-redis:6379/0"
+
+  - it: should point ML_API_HOST at the ml-api service
+    asserts:
+      - equal:
+          path: data.ML_API_HOST
+          value: "http://RELEASE-NAME-obico-ml-api:3333"
+
+  - it: should set INTERNAL_MEDIA_HOST at the web service
+    asserts:
+      - equal:
+          path: data.INTERNAL_MEDIA_HOST
+          value: "http://RELEASE-NAME-obico-web:3334"
+
+  - it: should disable debug and webpack loader by default
+    asserts:
+      - equal:
+          path: data.DEBUG
+          value: "False"
+      - equal:
+          path: data.WEBPACK_LOADER_ENABLED
+          value: "False"
+
+  - it: should set SITE_USES_HTTPS to False by default
+    asserts:
+      - equal:
+          path: data.SITE_USES_HTTPS
+          value: "False"
+
+  - it: should reflect siteUsesHttps when enabled
+    set:
+      obico.siteUsesHttps: true
+    asserts:
+      - equal:
+          path: data.SITE_USES_HTTPS
+          value: "True"
+
+  - it: should allow overriding DATABASE_URL
+    set:
+      database.url: "postgresql://u:p@db:5432/obico"
+    asserts:
+      - equal:
+          path: data.DATABASE_URL
+          value: "postgresql://u:p@db:5432/obico"
+
+  - it: should use the external redis url when redis disabled
+    set:
+      redis.enabled: false
+      redis.externalUrl: "redis://my-redis:6379/1"
+    asserts:
+      - equal:
+          path: data.REDIS_URL
+          value: "redis://my-redis:6379/1"
+
+  - it: should merge extra env
+    set:
+      obico.extraEnv:
+        EMAIL_HOST: smtp.example.com
+    asserts:
+      - equal:
+          path: data.EMAIL_HOST
+          value: "smtp.example.com"
+
+  - it: should not set DATABASE_URL in the ConfigMap when using existingSecret
+    set:
+      database.existingSecret: my-db-secret
+    asserts:
+      - notExists:
+          path: data.DATABASE_URL
+
+  - it: should not set DATABASE_URL in the ConfigMap when composing from host
+    set:
+      database.host: obico-db-pooler
+      database.user: obico
+      database.name: obico
+      database.passwordSecret: obico-db-app
+    asserts:
+      - notExists:
+          path: data.DATABASE_URL
+
+  - it: should reject setting both existingSecret and host
+    set:
+      database.existingSecret: my-db-secret
+      database.host: obico-db-pooler
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.existingSecret and database.host are mutually exclusive: set one or the other"
+
+  - it: should require user when composing from host
+    set:
+      database.host: obico-db-pooler
+      database.name: obico
+      database.passwordSecret: obico-db-app
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.host is set: database.user is required to compose DATABASE_URL"
+
+  - it: should require name when composing from host
+    set:
+      database.host: obico-db-pooler
+      database.user: obico
+      database.passwordSecret: obico-db-app
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.host is set: database.name is required to compose DATABASE_URL"
+
+  - it: should require passwordSecret when composing from host
+    set:
+      database.host: obico-db-pooler
+      database.user: obico
+      database.name: obico
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.host is set: database.passwordSecret is required to source the password"
+
+  - it: should default CSRF_TRUSTED_ORIGINS to an empty list
+    asserts:
+      - equal:
+          path: data.CSRF_TRUSTED_ORIGINS
+          value: "[]"
+
+  - it: should derive CSRF_TRUSTED_ORIGINS from the ingress host over https
+    set:
+      ingress.enabled: true
+      obico.siteUsesHttps: true
+    asserts:
+      - equal:
+          path: data.CSRF_TRUSTED_ORIGINS
+          value: '["https://obico.example.com"]'
+
+  - it: should derive CSRF_TRUSTED_ORIGINS from the httpRoute hostname
+    set:
+      httpRoute.enabled: true
+      obico.siteUsesHttps: true
+    asserts:
+      - equal:
+          path: data.CSRF_TRUSTED_ORIGINS
+          value: '["https://obico.example.com"]'
+
+  - it: should use explicit csrfTrustedOrigins when set
+    set:
+      obico.csrfTrustedOrigins:
+        - https://custom.example.com
+    asserts:
+      - equal:
+          path: data.CSRF_TRUSTED_ORIGINS
+          value: '["https://custom.example.com"]'
+
+  - it: should omit ML_API_HOST when ml-api is disabled and no external host is set
+    set:
+      mlApi.enabled: false
+    asserts:
+      - notExists:
+          path: data.ML_API_HOST
+
+  - it: should point ML_API_HOST at externalHost when ml-api is disabled
+    set:
+      mlApi.enabled: false
+      mlApi.externalHost: http://ml-api.example:3333
+    asserts:
+      - equal:
+          path: data.ML_API_HOST
+          value: http://ml-api.example:3333
+
+  - it: should reject CSRF_TRUSTED_ORIGINS in extraEnv
+    set:
+      obico.extraEnv:
+        CSRF_TRUSTED_ORIGINS: "[]"
+    asserts:
+      - failedTemplate:
+          errorMessage: 'obico.extraEnv must not set the chart-managed key "CSRF_TRUSTED_ORIGINS"; configure it via its dedicated value instead'
+
+  - it: should reject a chart-managed key in extraEnv
+    set:
+      obico.extraEnv:
+        REDIS_URL: redis://evil:6379
+    asserts:
+      - failedTemplate:
+          errorMessage: 'obico.extraEnv must not set the chart-managed key "REDIS_URL"; configure it via its dedicated value instead'
+
+  - it: should reject a chart-managed key in extraSecretEnv
+    set:
+      obico.extraSecretEnv:
+        DJANGO_SECRET_KEY: hunter2
+    asserts:
+      - failedTemplate:
+          errorMessage: 'obico.extraSecretEnv must not set the chart-managed key "DJANGO_SECRET_KEY"; configure it via its dedicated value instead'
+
+  - it: should reject the compose-mode password key in extraEnv
+    set:
+      obico.extraEnv:
+        OBICO_DB_PASSWORD: hunter2
+    asserts:
+      - failedTemplate:
+          errorMessage: 'obico.extraEnv must not set the chart-managed key "OBICO_DB_PASSWORD"; configure it via its dedicated value instead'

--- a/charts/obico/tests/deployment_ml_api_test.yaml
+++ b/charts/obico/tests/deployment_ml_api_test.yaml
@@ -1,0 +1,107 @@
+suite: test ml-api deployment
+templates:
+  - deployment-ml-api.yaml
+tests:
+  - it: should create an ml-api Deployment by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-ml-api
+
+  - it: should not create ml-api when disabled
+    set:
+      mlApi.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use the slim CPU ml-api image by default
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^ghcr\.io/thespaghettidetective/obico-ml-api-cpu:release$'
+      - notExists:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+
+  - it: should use the CUDA image and request a GPU when gpu is enabled
+    set:
+      mlApi.gpu: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^ghcr\.io/thespaghettidetective/obico-ml-api-gpu:release$'
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+          value: 1
+
+  - it: should honor a custom gpu resource name
+    set:
+      mlApi.gpu: true
+      mlApi.gpuResources:
+        nvidia.com/mig-1g.5gb: 2
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/mig-1g.5gb"]
+          value: 2
+
+  - it: should expose port 3333
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 3333
+            protocol: TCP
+
+  - it: should run gunicorn
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: gunicorn
+
+  - it: should set the ml-api component label
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: ml-api
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: ml-api
+
+  - it: should honor replicaCount
+    set:
+      mlApi.replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: should use a cheap socket liveness probe and an http readiness probe
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /hc/
+
+  - it: should not automount the service account token
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should keep the name within 63 chars for a long release name
+    # ml-api carries the longest component suffix (-ml-api); the fullname helper
+    # reserves room so the DNS label stays valid even at a max-length release name.
+    release:
+      name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: '^.{1,63}$'

--- a/charts/obico/tests/deployment_web_test.yaml
+++ b/charts/obico/tests/deployment_web_test.yaml
@@ -1,0 +1,318 @@
+suite: test web deployment
+templates:
+  - deployment-web.yaml
+  - configmap.yaml
+  - secret.yaml
+tests:
+  - it: should create a single web Deployment
+    template: deployment-web.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-web
+
+  - it: should run a single replica
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should set the web component label on selector and pod
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: web
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: web
+
+  - it: should run collectstatic and migrate init containers
+    template: deployment-web.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: collectstatic
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: migrate
+
+  - it: should run collectstatic as root but drop capabilities and block privilege escalation
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 0
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: should have server and tasks containers
+    template: deployment-web.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: server
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: tasks
+
+  - it: should use the web image for both containers
+    template: deployment-web.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^ghcr\.io/thespaghettidetective/obico-web:release$'
+      - matchRegex:
+          path: spec.template.spec.containers[1].image
+          pattern: '^ghcr\.io/thespaghettidetective/obico-web:release$'
+
+  - it: should expose the http port on the server container
+    template: deployment-web.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 3334
+            protocol: TCP
+
+  - it: should run daphne as the server command
+    template: deployment-web.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: daphne
+
+  - it: should run celery as the tasks command
+    template: deployment-web.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].command
+          content: celery
+
+  - it: should write the celery beat schedule to the writable /data volume
+    # The container runs as non-root and /app is read-only, so beat's default
+    # celerybeat-schedule (in the working directory) would crash the worker.
+    template: deployment-web.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].command
+          content: --schedule
+      - contains:
+          path: spec.template.spec.containers[1].command
+          content: /data/celerybeat-schedule
+
+  - it: should mount the static parent before the nested media child on the server
+    # static (/app/static_build, emptyDir) must precede media
+    # (/app/static_build/media, PVC) so the parent mount never shadows the media
+    # PVC — otherwise uploads land in the emptyDir and are lost on restart.
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
+          value: /app/static_build
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[2].mountPath
+          value: /app/static_build/media
+
+  - it: should load env from the ConfigMap and Secret
+    template: deployment-web.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: RELEASE-NAME-obico
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: RELEASE-NAME-obico
+
+  - it: should mount data, media and static volumes on the server
+    template: deployment-web.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /data
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: media
+            mountPath: /app/static_build/media
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: static
+            mountPath: /app/static_build
+
+  - it: should set the service account
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-obico
+
+  - it: should use a cheap socket liveness probe and an http readiness probe
+    template: deployment-web.yaml
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /hc/
+
+  - it: should not give the tasks container a liveness probe
+    template: deployment-web.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[1].livenessProbe
+
+  - it: should not automount the service account token
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should align fsGroup with the non-root containers and root collectstatic
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 65534
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 65534
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 0
+
+  - it: should inject DATABASE_URL from a Secret when using existingSecret
+    template: deployment-web.yaml
+    set:
+      database.existingSecret: my-db-secret
+      database.existingSecretKey: DATABASE_URL
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: DATABASE_URL
+
+  - it: should inject DATABASE_URL into collectstatic, migrate and tasks under existingSecret
+    template: deployment-web.yaml
+    set:
+      database.existingSecret: my-db-secret
+      database.existingSecretKey: DATABASE_URL
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: DATABASE_URL
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: DATABASE_URL
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: DATABASE_URL
+
+  - it: should compose DATABASE_URL and inject the password env in compose mode
+    template: deployment-web.yaml
+    set:
+      database.host: obico-db-pooler
+      database.port: 5432
+      database.user: obico
+      database.name: obico
+      database.passwordSecret: obico-db-app
+      database.passwordSecretKey: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OBICO_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: obico-db-app
+                key: password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_URL
+            value: "postgresql://obico:$(OBICO_DB_PASSWORD)@obico-db-pooler:5432/obico"
+
+  - it: should inject the composed DATABASE_URL into collectstatic, migrate and tasks
+    template: deployment-web.yaml
+    set:
+      database.host: obico-db-pooler
+      database.user: obico
+      database.name: obico
+      database.passwordSecret: obico-db-app
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: DATABASE_URL
+            value: "postgresql://obico:$(OBICO_DB_PASSWORD)@obico-db-pooler:5432/obico"
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: DATABASE_URL
+            value: "postgresql://obico:$(OBICO_DB_PASSWORD)@obico-db-pooler:5432/obico"
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: DATABASE_URL
+            value: "postgresql://obico:$(OBICO_DB_PASSWORD)@obico-db-pooler:5432/obico"
+
+  - it: should reference the existing secret in envFrom when obico.existingSecret is set
+    template: deployment-web.yaml
+    set:
+      obico.existingSecret: obico-secrets
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: obico-secrets
+      - contains:
+          path: spec.template.spec.containers[1].envFrom
+          content:
+            secretRef:
+              name: obico-secrets

--- a/charts/obico/tests/httproute_test.yaml
+++ b/charts/obico/tests/httproute_test.yaml
@@ -1,0 +1,205 @@
+suite: test httproute
+templates:
+  - httproute.yaml
+tests:
+  - it: should not create HTTPRoute by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create HTTPRoute when enabled
+    set:
+      httpRoute.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+
+  - it: should have correct metadata
+    set:
+      httpRoute.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico
+      - isNotEmpty:
+          path: metadata.labels
+
+  - it: should set parentRefs correctly
+    set:
+      httpRoute.enabled: true
+      httpRoute.parentRefs:
+        - name: my-gateway
+          namespace: custom-namespace
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].name
+          value: my-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: custom-namespace
+
+  - it: should set hostnames correctly
+    set:
+      httpRoute.enabled: true
+      httpRoute.hostnames:
+        - obico.example.com
+        - obico.alt.com
+    asserts:
+      - contains:
+          path: spec.hostnames
+          content: obico.example.com
+      - contains:
+          path: spec.hostnames
+          content: obico.alt.com
+
+  - it: should point the backendRef at the web service
+    set:
+      httpRoute.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-obico-web
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 3334
+
+  - it: should use a custom service port
+    set:
+      httpRoute.enabled: true
+      service.web.port: 8080
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8080
+
+  - it: should set path match correctly
+    set:
+      httpRoute.enabled: true
+      httpRoute.rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+
+  - it: should support custom annotations
+    set:
+      httpRoute.enabled: true
+      httpRoute.annotations:
+        custom.annotation/key: "value"
+    asserts:
+      - equal:
+          path: metadata.annotations["custom.annotation/key"]
+          value: "value"
+
+  - it: should support filters
+    set:
+      httpRoute.enabled: true
+      httpRoute.rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+          filters:
+            - type: RequestHeaderModifier
+              requestHeaderModifier:
+                add:
+                  - name: X-Custom-Header
+                    value: custom-value
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestHeaderModifier
+
+  - it: should support weight in backendRef
+    set:
+      httpRoute.enabled: true
+      httpRoute.rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+          weight: 100
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].weight
+          value: 100
+
+  - it: should preserve a zero backendRef weight (drain)
+    set:
+      httpRoute.enabled: true
+      httpRoute.rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+          weight: 0
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].weight
+          value: 0
+
+  - it: should omit matches for a catch-all rule
+    # Gateway API treats an absent matches field as "match all"; rendering
+    # matches: null would fail the HTTPRoute CRD schema (matches must be a list).
+    set:
+      httpRoute.enabled: true
+      httpRoute.rules:
+        - filters:
+            - type: RequestHeaderModifier
+              requestHeaderModifier:
+                add:
+                  - name: X-Test
+                    value: "1"
+    asserts:
+      - notExists:
+          path: spec.rules[0].matches
+      - exists:
+          path: spec.rules[0].backendRefs
+
+  - it: should support multiple rules
+    set:
+      httpRoute.enabled: true
+      httpRoute.rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /api
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /web
+    asserts:
+      - lengthEqual:
+          path: spec.rules
+          count: 2
+
+  - it: should support sectionName in parentRefs
+    set:
+      httpRoute.enabled: true
+      httpRoute.parentRefs:
+        - name: cilium-gateway-internal
+          namespace: kube-system
+          sectionName: https-obico
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: https-obico
+
+  - it: should not have filters when not specified
+    set:
+      httpRoute.enabled: true
+    asserts:
+      - isNull:
+          path: spec.rules[0].filters

--- a/charts/obico/tests/ingress_test.yaml
+++ b/charts/obico/tests/ingress_test.yaml
@@ -1,0 +1,66 @@
+suite: test ingress
+templates:
+  - ingress.yaml
+tests:
+  - it: should not create Ingress by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create Ingress when enabled
+    set:
+      ingress.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+
+  - it: should point the backend at the web service
+    set:
+      ingress.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-obico-web
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.name
+          value: http
+
+  - it: should configure default TLS
+    set:
+      ingress.enabled: true
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: obico-tls
+
+  - it: should set the ingress class name
+    set:
+      ingress.enabled: true
+      ingress.className: nginx
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+
+  - it: should have no annotations by default
+    set:
+      ingress.enabled: true
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: should apply custom annotations when specified
+    set:
+      ingress.enabled: true
+      ingress.annotations:
+        nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+        cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    asserts:
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
+          value: "100m"
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: "letsencrypt-prod"

--- a/charts/obico/tests/notes_test.yaml
+++ b/charts/obico/tests/notes_test.yaml
@@ -1,0 +1,34 @@
+suite: test NOTES output
+templates:
+  - NOTES.txt
+tests:
+  - it: should report the SQLite default in NOTES
+    asserts:
+      - matchRegexRaw:
+          pattern: 'Database: sqlite:////data/db\.sqlite3'
+
+  - it: should report an existingSecret database in NOTES
+    set:
+      database.existingSecret: obico-db
+    asserts:
+      - matchRegexRaw:
+          pattern: 'Database: external \(full DSN from secret obico-db\)'
+
+  - it: should report the composed database in NOTES
+    set:
+      database.host: obico-db-pooler
+      database.user: obico
+      database.name: obico
+      database.passwordSecret: obico-db-app
+    asserts:
+      - matchRegexRaw:
+          pattern: 'Database: postgresql://obico@obico-db-pooler:5432/obico \(password from secret obico-db-app\)'
+
+  - it: should tell the operator to create the admin via createsuperuser
+    asserts:
+      # Self-service signup is disabled by default and there is no first-user-is-staff
+      # logic, so NOTES must point at manage.py createsuperuser, not the web UI.
+      - matchRegexRaw:
+          pattern: 'python manage\.py createsuperuser'
+      - notMatchRegexRaw:
+          pattern: 'signing up in the web UI'

--- a/charts/obico/tests/pvc_test.yaml
+++ b/charts/obico/tests/pvc_test.yaml
@@ -1,0 +1,75 @@
+suite: test persistence
+templates:
+  - pvc-data.yaml
+  - pvc-media.yaml
+tests:
+  - it: should create the data PVC by default
+    template: pvc-data.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-data
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+      - equal:
+          path: spec.resources.requests.storage
+          value: 1Gi
+
+  - it: should create the media PVC by default
+    template: pvc-media.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-media
+      - equal:
+          path: spec.resources.requests.storage
+          value: 10Gi
+
+  - it: should not create the data PVC when disabled
+    template: pvc-data.yaml
+    set:
+      persistence.data.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create the data PVC when using an existing claim
+    template: pvc-data.yaml
+    set:
+      persistence.data.existingClaim: my-claim
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should add a keep resource-policy annotation when retain is true
+    template: pvc-data.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: should not add the keep annotation when retain is false
+    template: pvc-data.yaml
+    set:
+      persistence.data.retain: false
+    asserts:
+      - notExists:
+          path: metadata.annotations["helm.sh/resource-policy"]
+
+  - it: should set a storage class when provided
+    template: pvc-media.yaml
+    set:
+      persistence.media.storageClassName: fast-ssd
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: fast-ssd

--- a/charts/obico/tests/redis_test.yaml
+++ b/charts/obico/tests/redis_test.yaml
@@ -1,0 +1,71 @@
+suite: test bundled redis
+templates:
+  - redis.yaml
+tests:
+  - it: should create redis Deployment and Service by default
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should not create redis when disabled
+    set:
+      redis.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a redis Deployment
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-redis
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^redis:[0-9]'
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: redis
+            containerPort: 6379
+            protocol: TCP
+
+  - it: should label the redis pod with its component
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: redis
+
+  - it: should not automount the service account token
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should create a redis Service
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-redis
+      - equal:
+          path: spec.ports[0].port
+          value: 6379
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: redis
+
+  - it: should allow a custom redis image tag
+    documentIndex: 0
+    set:
+      redis.image.tag: "8.0-alpine"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: redis:8.0-alpine

--- a/charts/obico/tests/secret_test.yaml
+++ b/charts/obico/tests/secret_test.yaml
@@ -1,0 +1,39 @@
+suite: test secret
+templates:
+  - secret.yaml
+tests:
+  - it: should create a Secret with a Django secret key
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico
+      - isNotEmpty:
+          path: stringData.DJANGO_SECRET_KEY
+
+  - it: should use the provided secret key
+    set:
+      obico.secretKey: my-fixed-key
+    asserts:
+      - equal:
+          path: stringData.DJANGO_SECRET_KEY
+          value: my-fixed-key
+
+  - it: should merge extra secret env
+    set:
+      obico.extraSecretEnv:
+        EMAIL_HOST_PASSWORD: s3cr3t
+    asserts:
+      - equal:
+          path: stringData.EMAIL_HOST_PASSWORD
+          value: s3cr3t
+
+  - it: should not render a Secret when existingSecret is set
+    set:
+      obico.existingSecret: obico-secrets
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/obico/tests/service_test.yaml
+++ b/charts/obico/tests/service_test.yaml
@@ -1,0 +1,84 @@
+suite: test services
+templates:
+  - service.yaml
+tests:
+  - it: should create web and ml-api services by default
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should create the web service
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-web
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 3334
+            targetPort: http
+            protocol: TCP
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: web
+
+  - it: should create the ml-api service
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-ml-api
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 3333
+            targetPort: http
+            protocol: TCP
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: ml-api
+
+  - it: should not create the ml-api service when ml-api disabled
+    set:
+      mlApi.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-web
+
+  - it: should support a custom web port
+    documentIndex: 0
+    set:
+      service.web.port: 8080
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+
+  - it: should have no annotations by default on the web service
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: should support custom annotations on the web service
+    documentIndex: 0
+    set:
+      service.web.annotations:
+        custom.annotation/key: "value"
+    asserts:
+      - equal:
+          path: metadata.annotations["custom.annotation/key"]
+          value: "value"

--- a/charts/obico/tests/serviceaccount_test.yaml
+++ b/charts/obico/tests/serviceaccount_test.yaml
@@ -1,0 +1,37 @@
+suite: test service account
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: should create a ServiceAccount by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico
+
+  - it: should not create a ServiceAccount when create is false
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use a custom service account name
+    set:
+      serviceAccount.name: my-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-sa
+
+  - it: should apply custom annotations
+    set:
+      serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::123:role/obico
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: arn:aws:iam::123:role/obico

--- a/charts/obico/values.schema.json
+++ b/charts/obico/values.schema.json
@@ -1,0 +1,610 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Obico Values",
+  "type": "object",
+  "properties": {
+    "image": {
+      "type": "object",
+      "properties": {
+        "web": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "Web image repository"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"],
+              "description": "Web image pull policy"
+            },
+            "tag": {
+              "type": "string",
+              "description": "Overrides the web image tag whose default is the 'release' moving tag"
+            }
+          },
+          "required": ["repository", "pullPolicy"]
+        },
+        "mlApi": {
+          "type": "object",
+          "properties": {
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"],
+              "description": "ML API image pull policy"
+            },
+            "cpu": {
+              "type": "object",
+              "properties": {
+                "repository": {
+                  "type": "string",
+                  "description": "CPU-only ml-api image repository"
+                },
+                "tag": {
+                  "type": "string",
+                  "description": "Overrides the CPU ml-api image tag whose default is the 'release' moving tag"
+                }
+              },
+              "required": ["repository"]
+            },
+            "gpu": {
+              "type": "object",
+              "properties": {
+                "repository": {
+                  "type": "string",
+                  "description": "CUDA (GPU) ml-api image repository"
+                },
+                "tag": {
+                  "type": "string",
+                  "description": "Overrides the GPU ml-api image tag whose default is the 'release' moving tag"
+                }
+              },
+              "required": ["repository"]
+            }
+          },
+          "required": ["pullPolicy", "cpu", "gpu"]
+        }
+      },
+      "required": ["web", "mlApi"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Image pull secrets"
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the name of the chart"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the fullname of the chart"
+    },
+    "obico": {
+      "type": "object",
+      "properties": {
+        "debug": {
+          "type": "boolean",
+          "description": "Enable Django debug mode"
+        },
+        "siteUsesHttps": {
+          "type": "boolean",
+          "description": "Set true when served over HTTPS"
+        },
+        "csrfTrustedOrigins": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "CSRF trusted origins; auto-derived from ingress/httpRoute when empty"
+        },
+        "secretKey": {
+          "type": "string",
+          "description": "Django SECRET_KEY (set explicitly for GitOps; empty regenerates on render-only paths)"
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Pre-created Secret holding DJANGO_SECRET_KEY and other sensitive env"
+        },
+        "extraEnv": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra non-sensitive environment variables (string key-value pairs)"
+        },
+        "extraSecretEnv": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra sensitive environment variables (string key-value pairs)"
+        }
+      }
+    },
+    "database": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "Django DATABASE_URL connection string"
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Existing Secret holding DATABASE_URL"
+        },
+        "existingSecretKey": {
+          "type": "string",
+          "description": "Key in existingSecret holding DATABASE_URL"
+        },
+        "host": {
+          "type": "string",
+          "description": "PostgreSQL host; when set, DATABASE_URL is composed from the fields below (mutually exclusive with existingSecret)"
+        },
+        "port": {
+          "type": "integer",
+          "description": "PostgreSQL port (compose mode)"
+        },
+        "name": {
+          "type": "string",
+          "description": "PostgreSQL database name (compose mode)"
+        },
+        "user": {
+          "type": "string",
+          "description": "PostgreSQL user (compose mode)"
+        },
+        "passwordSecret": {
+          "type": "string",
+          "description": "Existing Secret holding the PostgreSQL password (compose mode)"
+        },
+        "passwordSecretKey": {
+          "type": "string",
+          "description": "Key in passwordSecret holding the password"
+        }
+      }
+    },
+    "web": {
+      "type": "object",
+      "properties": {
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Command for the Daphne ASGI server"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      }
+    },
+    "tasks": {
+      "type": "object",
+      "properties": {
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Command for the Celery worker"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      }
+    },
+    "mlApi": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Deploy the ML inference API"
+        },
+        "externalHost": {
+          "type": "string",
+          "description": "External ML inference API URL, used when enabled is false"
+        },
+        "gpu": {
+          "type": "boolean",
+          "description": "Run the CUDA (GPU) ml-api image and request the accelerator; defaults to the slim CPU image"
+        },
+        "gpuResources": {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["integer", "string"]
+          },
+          "description": "Accelerator resources merged into the ml-api container limits when gpu is true"
+        },
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of ml-api replicas"
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Command for the gunicorn inference server"
+        },
+        "securityContext": {
+          "type": "object",
+          "description": "Security context for the ml-api container"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      },
+      "required": ["enabled"]
+    },
+    "redis": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Deploy a bundled in-cluster Redis"
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "Redis image repository"
+            },
+            "tag": {
+              "type": "string",
+              "description": "Redis image tag"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"],
+              "description": "Redis image pull policy"
+            }
+          },
+          "required": ["repository", "tag"]
+        },
+        "externalUrl": {
+          "type": "string",
+          "description": "External Redis URL used when redis.enabled is false"
+        },
+        "securityContext": {
+          "type": "object",
+          "description": "Security context for the redis container"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      },
+      "required": ["enabled"]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "web": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer"],
+              "description": "Service type for the web UI"
+            },
+            "port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535,
+              "description": "Web HTTP port"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Annotations for the web service (must be string key-value pairs)"
+            }
+          },
+          "required": ["type", "port"]
+        },
+        "mlApi": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer"],
+              "description": "Service type for the ml-api"
+            },
+            "port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535,
+              "description": "ML API HTTP port"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Annotations for the ml-api service (must be string key-value pairs)"
+            }
+          },
+          "required": ["type", "port"]
+        }
+      },
+      "required": ["web", "mlApi"]
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable ingress"
+        },
+        "className": {
+          "type": "string",
+          "description": "Ingress class name"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Ingress annotations (must be string key-value pairs)"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string",
+                "description": "Hostname"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "pathType": {
+                      "type": "string",
+                      "enum": ["Prefix", "Exact", "ImplementationSpecific"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "secretName": {
+                "type": "string"
+              },
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": ["enabled"]
+    },
+    "httpRoute": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable HTTPRoute (Gateway API)"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "HTTPRoute annotations (must be string key-value pairs)"
+        },
+        "parentRefs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Gateway name"
+              },
+              "namespace": {
+                "type": "string",
+                "description": "Gateway namespace"
+              },
+              "sectionName": {
+                "type": "string",
+                "description": "Optional: specific listener on the Gateway"
+              }
+            }
+          },
+          "description": "Parent Gateway references"
+        },
+        "hostnames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Hostnames for the route"
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "matches": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "filters": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "weight": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 1000000
+              }
+            }
+          },
+          "description": "Routing rules"
+        }
+      },
+      "required": ["enabled"]
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/volume"
+        },
+        "media": {
+          "$ref": "#/definitions/volume"
+        }
+      },
+      "required": ["data", "media"]
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Security context for the pod"
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Security context for the server, tasks and migrate containers"
+    },
+    "podAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Pod annotations (must be string key-value pairs)"
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Pod labels"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Specifies whether a service account should be created"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations to add to the service account (must be string key-value pairs)"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the service account to use"
+        }
+      },
+      "required": ["create"]
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node selector"
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Tolerations"
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity rules"
+    }
+  },
+  "required": ["image", "service", "persistence", "redis", "mlApi"],
+  "definitions": {
+    "resources": {
+      "type": "object",
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "memory": {
+              "type": "string",
+              "pattern": "^[0-9]+(\\.[0-9]+)?(Ki|Mi|Gi|Ti|Pi|Ei|K|M|G|T|P|E)?$",
+              "description": "Memory request"
+            },
+            "cpu": {
+              "type": "string",
+              "pattern": "^[0-9]+(\\.[0-9]+)?m?$",
+              "description": "CPU request"
+            }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "memory": {
+              "type": "string",
+              "pattern": "^[0-9]+(\\.[0-9]+)?(Ki|Mi|Gi|Ti|Pi|Ei|K|M|G|T|P|E)?$",
+              "description": "Memory limit"
+            },
+            "cpu": {
+              "type": "string",
+              "pattern": "^[0-9]+(\\.[0-9]+)?m?$",
+              "description": "CPU limit"
+            }
+          }
+        }
+      }
+    },
+    "volume": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable this volume"
+        },
+        "storageClassName": {
+          "type": "string",
+          "description": "Storage class name"
+        },
+        "accessMode": {
+          "type": "string",
+          "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"],
+          "description": "Access mode"
+        },
+        "size": {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?(Ki|Mi|Gi|Ti|Pi|Ei|K|M|G|T|P|E)?$",
+          "description": "Size of the volume"
+        },
+        "existingClaim": {
+          "type": "string",
+          "description": "Use an existing PVC"
+        },
+        "retain": {
+          "type": "boolean",
+          "description": "Keep the PVC on uninstall"
+        }
+      },
+      "required": ["enabled"]
+    }
+  }
+}

--- a/charts/obico/values.yaml
+++ b/charts/obico/values.yaml
@@ -1,0 +1,345 @@
+# Default values for obico
+# Obico is a multi-service Django stack: a web app (Daphne/ASGI), a Celery
+# worker, an ML inference API and Redis. The web and tasks containers share a
+# single pod so they can share the SQLite database on a ReadWriteOnce volume.
+
+# -- Container images. Built from obico-server source by the in-repo workflow
+# (.github/workflows/build-images.yaml) and published to GHCR under the
+# repository owner's namespace (ghcr.io/thespaghettidetective/* upstream). Each
+# tag defaults to the "release" moving tag the workflow publishes on the release
+# branch; pin a specific tag (a CalVer like 2026.7.1 or sha-<short>) for
+# reproducibility.
+image:
+  # -- Web application image (Django + Celery)
+  web:
+    repository: ghcr.io/thespaghettidetective/obico-web
+    pullPolicy: IfNotPresent
+    # -- Overrides the image tag whose default is the "release" moving tag
+    tag: ""
+  # -- ML inference API images. Two variants are published from the same source:
+  # a slim CPU-only image (default) and a CUDA image for GPU inference.
+  # mlApi.gpu selects which one runs; configure each variant independently.
+  mlApi:
+    pullPolicy: IfNotPresent
+    # -- CPU-only inference image (slim). Used when mlApi.gpu is false.
+    cpu:
+      repository: ghcr.io/thespaghettidetective/obico-ml-api-cpu
+      # -- Overrides the CPU image tag whose default is the "release" moving tag
+      tag: ""
+    # -- CUDA inference image (large). Used when mlApi.gpu is true.
+    gpu:
+      repository: ghcr.io/thespaghettidetective/obico-ml-api-gpu
+      # -- Overrides the GPU image tag whose default is the "release" moving tag
+      tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# -- Obico application configuration (rendered into the env ConfigMap/Secret)
+obico:
+  # -- Enable Django debug mode (never enable in production)
+  debug: false
+  # -- Set to true when the site is served over HTTPS (behind a TLS ingress/gateway)
+  siteUsesHttps: false
+  # -- CSRF trusted origins (Django 4+ rejects HTTPS POSTs from untrusted origins).
+  # Leave empty to auto-derive from the enabled ingress hosts / HTTPRoute
+  # hostnames using the scheme implied by siteUsesHttps. Set explicitly to
+  # override, e.g. ["https://obico.example.com"].
+  csrfTrustedOrigins: []
+  # -- Django SECRET_KEY.
+  # IMPORTANT: leave empty only for a quick `helm install` test. The empty-value
+  # fallback reuses the live Secret on upgrades but REGENERATES the key on any
+  # render-only path (helm template, --dry-run, helm diff, ArgoCD) — rotating it
+  # logs every user out and rolls the pod on every sync. For GitOps set a stable
+  # value here (e.g. `openssl rand -base64 48`) or use existingSecret below.
+  secretKey: ""
+  # -- Reference a pre-created Secret for sensitive env (must contain
+  # DJANGO_SECRET_KEY and any other secret keys). When set, the chart does not
+  # create its own Secret and extraSecretEnv is ignored. Recommended for GitOps.
+  existingSecret: ""
+  # -- Extra non-sensitive environment variables (key/value) for web and tasks.
+  # Chart-managed keys (DATABASE_URL, REDIS_URL, ...) are rejected here.
+  # Example: EMAIL_HOST: smtp.example.com
+  extraEnv: {}
+  # -- Extra sensitive environment variables (key/value) stored in the Secret.
+  # Example: EMAIL_HOST_PASSWORD: s3cr3t
+  extraSecretEnv: {}
+
+# -- Database configuration. Defaults to SQLite on the data volume.
+# WARNING: SQLite is for evaluation only. The server and the Celery worker run
+# as separate processes writing the same file, so under load they will hit
+# "database is locked" errors. Upstream ships PostgreSQL only. For any real use
+# set url to an external postgresql:// DSN, or reference a Secret via
+# existingSecret/existingSecretKey.
+database:
+  # -- Database connection string (Django DATABASE_URL). Used only when neither
+  # existingSecret nor host is set.
+  url: "sqlite:////data/db.sqlite3"
+  # -- Use a key from an existing Secret for the full DATABASE_URL instead of url
+  existingSecret: ""
+  # -- Key inside existingSecret holding the DATABASE_URL value
+  existingSecretKey: "DATABASE_URL"
+  # -- PostgreSQL host. When set, DATABASE_URL is composed from the fields below
+  # and the password is injected from passwordSecret at runtime (so it never
+  # lands in the ConfigMap or in git). Mutually exclusive with existingSecret.
+  # Point this at a connection pooler service (e.g. a CloudNativePG Pooler /
+  # PgBouncer) to multiplex many app connections onto few server connections.
+  # Run the pooler in TRANSACTION mode: Obico keeps connections open
+  # (CONN_MAX_AGE=600), so session mode pins idle connections and exhausts the
+  # pool (see the Database section of the README).
+  # The password must be URL-safe; the chart does not URL-encode it.
+  host: ""
+  # -- PostgreSQL port (compose mode)
+  port: 5432
+  # -- PostgreSQL database name (compose mode; required when host is set)
+  name: ""
+  # -- PostgreSQL user (compose mode; required when host is set)
+  user: ""
+  # -- Name of an existing Secret holding the PostgreSQL password (compose mode;
+  # required when host is set)
+  passwordSecret: ""
+  # -- Key inside passwordSecret holding the password
+  passwordSecretKey: "password"
+
+# -- Web pod configuration (server + tasks containers, plus init containers)
+web:
+  # -- Command for the Daphne ASGI server (serves API, frontend and websockets)
+  command:
+    - daphne
+    - -b
+    - 0.0.0.0
+    - -p
+    - "3334"
+    - config.routing:application
+  # -- Resource requests/limits for the server container
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "1Gi"
+      cpu: "1"
+
+# -- Celery worker (runs in the same pod as the web server)
+tasks:
+  # -- Command for the Celery worker with the embedded beat scheduler. The beat
+  # schedule DB is written under /data (a writable, persistent volume) because
+  # the container runs as non-root and the image's /app is not writable; the
+  # default (celerybeat-schedule in the working directory) would crash beat.
+  command:
+    - celery
+    - -A
+    - config
+    - worker
+    - --beat
+    - --schedule
+    - /data/celerybeat-schedule
+    - -l
+    - info
+    - -c
+    - "2"
+    - -Q
+    - realtime,celery
+  # -- Resource requests/limits for the tasks container
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
+# -- ML inference API (AI failure detection). Can be disabled.
+mlApi:
+  # -- Deploy the ML inference API
+  enabled: true
+  # -- External ML inference API URL, used when enabled is false. Obico still
+  # calls the ML API for prints that have AI detection on, so if you disable the
+  # bundled ml-api, either point this at an external instance (e.g.
+  # http://ml-api:3333) or make sure AI detection is off on every printer —
+  # otherwise picture uploads that request detection will error.
+  externalHost: ""
+  # -- Run the CUDA (GPU) inference image instead of the slim CPU default. When
+  # true the ml-api container uses image.mlApi.gpu and requests the accelerator
+  # from gpuResources; requires an NVIDIA GPU and device plugin on the node. The
+  # CPU image works everywhere and is far smaller, so leave this false unless you
+  # actually have a GPU.
+  gpu: false
+  # -- Accelerator resources merged into the ml-api container limits when gpu is
+  # true. Adjust for non-NVIDIA or MIG / time-sliced GPUs (e.g. nvidia.com/mig-1g.5gb: 1).
+  gpuResources:
+    nvidia.com/gpu: 1
+  # -- Number of ml-api replicas
+  replicaCount: 1
+  # -- Command for the gunicorn inference server
+  command:
+    - gunicorn
+    - --bind=0.0.0.0:3333
+    - --workers=1
+    - --access-logfile=-
+    - wsgi
+  # -- Security context for the ml-api container.
+  # Left empty (image default = root) because the upstream CUDA-based ml-api
+  # image is not validated to run unprivileged (model cache and runtime expect
+  # root). Harden here once confirmed it runs as non-root in your environment.
+  securityContext: {}
+  # -- Resource requests/limits for the ml-api container
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "500m"
+    limits:
+      memory: "2Gi"
+      cpu: "2"
+
+# -- Bundled Redis (Celery broker + Django Channels + cache)
+redis:
+  # -- Deploy a minimal in-cluster Redis. Disable to use an external Redis.
+  enabled: true
+  # -- Redis image (pinned; not tied to the chart appVersion)
+  image:
+    repository: redis
+    # renovate: datasource=docker depName=redis
+    tag: "8.8-alpine"
+    pullPolicy: IfNotPresent
+  # -- External Redis URL, used when redis.enabled is false
+  externalUrl: ""
+  # -- Security context for the redis container
+  securityContext:
+    runAsUser: 999
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  # -- Resource requests/limits for the redis container
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+      cpu: "200m"
+
+# -- Service configuration
+service:
+  # -- Web UI / API service (ClusterIP for Ingress/HTTPRoute)
+  web:
+    # -- Service type for the web UI
+    type: ClusterIP
+    # -- HTTP port
+    port: 3334
+    # -- Annotations for the web service
+    annotations: {}
+  # -- ML inference API service (internal)
+  mlApi:
+    # -- Service type for the ml-api
+    type: ClusterIP
+    # -- HTTP port
+    port: 3333
+    # -- Annotations for the ml-api service
+    annotations: {}
+
+# -- Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: obico.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: obico-tls
+      hosts:
+        - obico.example.com
+
+# -- HTTPRoute configuration (Gateway API)
+httpRoute:
+  enabled: false
+  annotations: {}
+  # -- Parent Gateway references
+  parentRefs:
+    - name: gateway
+      namespace: gateway-system
+      # sectionName: https-listener  # Optional: specific listener on the Gateway
+  # -- Hostnames for the route
+  hostnames:
+    - obico.example.com
+  # -- Routing rules
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+
+# -- Persistence configuration
+persistence:
+  # -- Data volume (SQLite database and persistent data)
+  data:
+    enabled: true
+    # -- Storage class name
+    storageClassName: ""
+    # -- Access mode
+    accessMode: ReadWriteOnce
+    # -- Size of the volume
+    size: 1Gi
+    # -- Use an existing PVC instead of creating one
+    existingClaim: ""
+    # -- Keep the PVC when the release is uninstalled
+    retain: true
+  # -- Media volume (user uploads, webcam frames, timelapses)
+  media:
+    enabled: true
+    # -- Storage class name
+    storageClassName: ""
+    # -- Access mode
+    accessMode: ReadWriteOnce
+    # -- Size of the volume
+    size: 10Gi
+    # -- Use an existing PVC instead of creating one
+    existingClaim: ""
+    # -- Keep the PVC when the release is uninstalled
+    retain: true
+
+# -- Security context for the pod.
+# fsGroup is load-bearing, not cosmetic: the server, tasks and migrate
+# containers run as non-root (65534, see securityContext below), so the data
+# and media volumes must be group-owned by that gid for them to write the
+# SQLite DB and media files. It also lets the non-root server read the static
+# assets generated by the root collectstatic init container. Keep them aligned.
+podSecurityContext:
+  fsGroup: 65534
+
+# -- Security context for the server, tasks and migrate containers
+securityContext:
+  runAsUser: 65534
+  runAsGroup: 65534
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod labels
+podLabels: {}
+
+# -- Service account configuration
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use
+  name: ""
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/ml_api/Containerfile.cpu
+++ b/ml_api/Containerfile.cpu
@@ -1,0 +1,45 @@
+# CPU-only build of the Obico ML failure-detection API.
+#
+# The GPU image (ml_api/Dockerfile, built on the CUDA ml_api_base) bakes in the
+# CUDA/cuDNN runtime plus both the darknet and ONNX inference runtimes — roughly
+# 3 GB compressed, most of which a CPU-only deployment never executes. This
+# image drops CUDA and darknet entirely: lib.detection_model.load_net() falls
+# back to the ONNX net when darknet cannot be imported, so ONNX Runtime (CPU)
+# alone serves inference. The result is an order of magnitude smaller and builds
+# without an NVIDIA toolchain.
+#
+# Python 3.8 mirrors the runtime of the CUDA base image (Ubuntu 20.04). Keep it
+# in lockstep with that base and with the pinned inference dependencies below.
+FROM python:3.8-slim
+
+# libgomp1: OpenMP runtime required by ONNX Runtime.
+# libglib2.0-0: shared object required by opencv-python-headless.
+RUN apt-get update \
+    && apt-get install --no-install-recommends --assume-yes \
+        curl ca-certificates libgomp1 libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# CPU inference stack: onnxruntime (not onnxruntime-gpu) and the headless OpenCV
+# build (no GUI/X11 dependencies). Pinned to releases that ship cp38 wheels.
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir \
+        onnxruntime==1.16.3 \
+        opencv-python-headless==4.9.0.80
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --requirement requirements.txt
+
+COPY . /app
+
+# Pre-fetch the ONNX model so the container needs no network at startup. The
+# darknet weights the GPU image also downloads are intentionally omitted.
+RUN mkdir -p /model_cache/ml_api/onnx \
+    && curl --fail --silent --show-error --location \
+        --output /model_cache/ml_api/onnx/model-weights.onnx \
+        "$(tr -d '\r' < model/model-weights.onnx.url)"
+
+EXPOSE 3333
+
+CMD ["gunicorn", "--bind", "0.0.0.0:3333", "--workers", "1", "wsgi"]


### PR DESCRIPTION
## What

Adds an official way to run the Obico server on Kubernetes, as discussed in #1141. Three parts:

1. **Helm chart** (`charts/obico/`) — deploys the full stack: `web` (Daphne) and `tasks` (Celery worker + beat) in one pod, `ml-api`, and Redis (bundled or external). External PostgreSQL via `DATABASE_URL`, Ingress or Gateway API for the web UI, PVC-backed media at `/app/static_build/media`, migrate and collectstatic as init containers.

2. **Image build workflow** (`.github/workflows/build-images.yaml`) — obico's docker-compose builds the images from source, so there are no ready-to-run images for a chart to consume. This workflow builds `web`, `ml-api-cpu`, and `ml-api-gpu` from the release branch and publishes them to GHCR under the repository owner's namespace, signed with cosign (keyless).

3. **CPU inference image** (`ml_api/Containerfile.cpu`) — a slim ONNX-Runtime-on-CPU image (~1 GB on disk vs ~7–8 GB for the CUDA image). `detection_model.load_net()` already falls back to the ONNX net when darknet is unavailable, so no application change was needed. Most self-hosted deployments run CPU inference, so this is the chart default; the existing CUDA image is the GPU variant, selected with `mlApi.gpu: true`.

## Scope

Matches the v1 list in #1141: web, tasks, ml_api, Redis (bundled or external), external Postgres via `DATABASE_URL`, Ingress + Gateway API, migrate/collectstatic init flow, documented env vars and secrets, and PVC media (ReadWriteOnce default; ReadWriteMany documented for multiple replicas). Out of scope for v1: HA guarantees, autoscaling, bundled Postgres, object storage.

## Notes for review

- **Images become project-owned on merge.** The workflow publishes under `ghcr.io/<repo-owner>/*` and the chart defaults to `ghcr.io/thespaghettidetective/*`, which line up when merged into this org. The images do not exist until the workflow first runs on `release` after merge.
- **The default image tag is the `release` moving tag.** Pin `image.*.tag` to a `sha-<short>` (immutable per commit) or a CalVer for a reproducible deployment.
- **The SQLite default is evaluation-only** (documented); real deployments point `database.url` at an external PostgreSQL. A connection pooler must run in transaction mode because Obico keeps connections open (`CONN_MAX_AGE=600`).
- Security: non-root containers with dropped capabilities, `automountServiceAccountToken: false` on every pod, an unauthenticated bundled Redis intended for in-cluster use only.

## Testing

`helm lint` is clean, 123 `helm-unittest` cases pass, `values.schema.json` validates `values.yaml`, and the README is generated by `helm-docs`. The CPU image was built and run: gunicorn starts and loads the ONNX model on the CPU.

I'm happy to maintain this going forward.
